### PR TITLE
Add validation script

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -22,4 +22,4 @@ jobs:
           npm install ESA-EarthCODE/open-science-catalog-validation#v1.0.0-rc.1
       - name: Validate
         run: |
-          npx open-science-catalog-validation ./{eo-missions,products,projects,themes,variables}
+          npx open-science-catalog-validation ./eo-missions ./products ./projects ./themes ./variables

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,25 @@
+name: Validate
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Prepare
+        run: |
+          npm install ESA-EarthCODE/open-science-catalog-validation#v1.0.0-rc.1
+      - name: Validate
+        run: |
+          npx open-science-catalog-validation ./{eo-missions,products,projects,themes,variables}


### PR DESCRIPTION
This adds validation of the catalog as GitHub action using https://github.com/ESA-EarthCODE/open-science-catalog-validation. Validation now runs on each PR and on pushes to main.