### PR TITLE
Shorten project ID

### DIFF
--- a/projects/catalog.json
+++ b/projects/catalog.json
@@ -744,7 +744,7 @@
     },
     {
       "rel": "child",
-      "href": "./promcom-production-of-lower-tropospheric-methane-and-carbon-monoxide-distributions-through-combined-use-of-esa-sentinel-5-precursor-shortwave-infrared-and-iasi-cris-thermal-infrared-satellite-data/collection.json",
+      "href": "./promcom-ch4-co-distributions-via-s5p-swir-iasi-cris-tir-data/collection.json",
       "type": "application/json",
       "title": "PROMCOM"
     },

--- a/projects/promcom-ch4-co-distributions-via-s5p-swir-iasi-cris-tir-data/collection.json
+++ b/projects/promcom-ch4-co-distributions-via-s5p-swir-iasi-cris-tir-data/collection.json
@@ -1,6 +1,6 @@
 {
   "type": "Collection",
-  "id": "promcom-production-of-lower-tropospheric-methane-and-carbon-monoxide-distributions-through-combined-use-of-esa-sentinel-5-precursor-shortwave-infrared-and-iasi-cris-thermal-infrared-satellite-data",
+  "id": "promcom-ch4-co-distributions-via-s5p-swir-iasi-cris-tir-data",
   "stac_version": "1.0.0",
   "description": "Production of lower tropospheric methane and carbon monoxide distributions through combined use of ESA Sentinel-5 Precursor shortwave infrared and IASI/CrIS thermal infrared satellite data",
   "links": [


### PR DESCRIPTION
This shortens the ID for a project that previously caused trouble for setups on Windows (filename too long).