### PR TITLE
Shorten project ID

### DIFF
--- a/projects/catalog.json
+++ b/projects/catalog.json
@@ -612,7 +612,7 @@
     },
     {
       "rel": "child",
-      "href": "./methane-emissions-in-the-northern-hemisphere-by-applying-both-data-from-earth-observing-eo-satellites-and-global-atmospheric-methane-inversion-model-estimates/collection.json",
+      "href": "./methane-emissions-in-the-northern-hemisphere-eo-data-and-global-atmospheric-methane-inversion-model-estimates/collection.json",
       "type": "application/json",
       "title": "MethEO"
     },

--- a/projects/methane-emissions-in-the-northern-hemisphere-eo-data-and-global-atmospheric-methane-inversion-model-estimates/collection.json
+++ b/projects/methane-emissions-in-the-northern-hemisphere-eo-data-and-global-atmospheric-methane-inversion-model-estimates/collection.json
@@ -1,6 +1,6 @@
 {
   "type": "Collection",
-  "id": "methane-emissions-in-the-northern-hemisphere-by-applying-both-data-from-earth-observing-eo-satellites-and-global-atmospheric-methane-inversion-model-estimates",
+  "id": "methane-emissions-in-the-northern-hemisphere-eo-data-and-global-atmospheric-methane-inversion-model-estimates",
   "stac_version": "1.0.0",
   "description": "Methane emissions in the Northern Hemisphere by applying both data from Earth Observing (EO) satellites and global atmospheric methane inversion model estimates",
   "links": [


### PR DESCRIPTION
This shortens the ID for a project that previously caused trouble for setups on Windows (filename too long).