### PR TITLE
Update collection.json oceanic fronts and currents

### DIFF
--- a/products/oceanic-current-fronts-world-ocean-circulation/collection.json
+++ b/products/oceanic-current-fronts-world-ocean-circulation/collection.json
@@ -1,8 +1,8 @@
 {
   "type": "Collection",
-  "id": "oceanic-current-fronts-world-ocean-circulation",
+  "id": "oceanic-current-fronts-world-ocean-circulation-GBLTR",
   "stac_version": "1.0.0",
-  "description": "Fronts derived from remote sensing SST observations by SEVIRI L3C from OSISAF and microwave  OI L4 SST from REMSS, over Agulhas region, (Western only for SEVIRI) North Atlantic.",
+  "description": "Fronts derived from high resolution remote sensing SST observations by SEVIRI L3C from OSISAF over Western Europe region. The product has a resolution of 0.05 deg and it is projected in WGS 84 (EPSG:4326)",
   "links": [
     {
       "rel": "root",
@@ -12,7 +12,7 @@
     },
     {
       "rel": "via",
-      "href": "https://www.worldoceancirculation.org/Products",
+      "href": "https://www.worldoceancirculation.org/Products#/metadata/a22d1f89-2690-4041-a16f-963923009f8b",
       "title": "Access"
     },
     {
@@ -55,11 +55,11 @@
     "https://stac-extensions.github.io/cf/v0.2.0/schema.json"
   ],
   "osc:project": "world-ocean-circulation",
-  "osc:status": "ongoing",
+  "osc:status": "completed",
   "osc:region": "Gibraltar",
   "osc:type": "product",
   "created": "2021-11-30T00:00:00Z",
-  "start_datetime": "2010-01-01T00:00:00Z",
+  "start_datetime": "2011-08-01T00:00:00Z",
   "end_datetime": "2020-12-31T23:59:59Z",
   "cf:parameter": [
     {
@@ -74,23 +74,23 @@
   ],
   "osc:missions": [],
   "updated": "2024-09-12T20:32:22.963110Z",
-  "title": "Oceanic/current fronts_Gibraltar",
+  "title": "Oceanic Fronts Gibraltar",
   "extent": {
     "spatial": {
       "bbox": [
         [
-          -5.4006553,
-          36.05875496,
-          -5.27666114,
-          36.15503755
+          -25,
+          30,
+          5,
+          50
         ]
       ]
     },
     "temporal": {
       "interval": [
         [
-          "2010-01-01T00:00:00Z",
-          "2020-12-31T23:59:59Z"
+          "2011-08-01T00:00:00Z",
+          "2021-12-31T23:59:59Z"
         ]
       ]
     }


### PR DESCRIPTION
This product - the oceanic fronts, is about 3 areas in the Atlantic. I reserved this one for the Gibraltar and I am going to create two collections for the other two ones. I updated the bounding box, time period and description of the product, as well as the hyperlink to match directly to the gibraltar product.

I have made an error in the start date on line 62. Will change it in the next iteration

  "start_datetime": "2010-01-01T00:00:00Z",
  "start_datetime": "2011-08-01T00:00:00Z",