### PR TITLE
Remove mostly empty osc:missions from projects

### DIFF
--- a/projects/3d-earth/collection.json
+++ b/projects/3d-earth/collection.json
@@ -125,7 +125,6 @@
   ],
   "start_datetime": "2019-10-22T00:00:00Z",
   "end_datetime": "2020-12-11T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.030110Z",
   "title": "3D-EARTH",
   "extent": {

--- a/projects/4d-antarctica/collection.json
+++ b/projects/4d-antarctica/collection.json
@@ -215,7 +215,6 @@
   ],
   "start_datetime": "2019-09-24T00:00:00Z",
   "end_datetime": "2022-10-15T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.006110Z",
   "title": "4D-ANTARCTICA",
   "extent": {

--- a/projects/4d-greenland/collection.json
+++ b/projects/4d-greenland/collection.json
@@ -173,7 +173,6 @@
   ],
   "start_datetime": "2020-08-26T00:00:00Z",
   "end_datetime": "2022-01-09T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.007110Z",
   "title": "4D-Greenland",
   "extent": {

--- a/projects/4datlantic-ebus-primus/collection.json
+++ b/projects/4datlantic-ebus-primus/collection.json
@@ -101,7 +101,6 @@
   ],
   "start_datetime": "2021-09-01T00:00:00Z",
   "end_datetime": "2023-09-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.005110Z",
   "title": "4DATLANTIC EBUS PRIMUS",
   "extent": {

--- a/projects/4dionosphere-swarm-vip/collection.json
+++ b/projects/4dionosphere-swarm-vip/collection.json
@@ -101,7 +101,6 @@
   ],
   "start_datetime": "2020-07-04T00:00:00Z",
   "end_datetime": "2022-04-16T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.984110Z",
   "title": "SWARM VIP",
   "extent": {

--- a/projects/4dmed-hydrology/collection.json
+++ b/projects/4dmed-hydrology/collection.json
@@ -131,7 +131,6 @@
   ],
   "start_datetime": "2022-01-01T00:00:00Z",
   "end_datetime": "2023-12-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.986110Z",
   "title": "4DMED-Hydrology",
   "extent": {

--- a/projects/advancing-the-study-of-extreme-weather-events-with-data-deep-learning-methods-and-climate-analysis/collection.json
+++ b/projects/advancing-the-study-of-extreme-weather-events-with-data-deep-learning-methods-and-climate-analysis/collection.json
@@ -81,7 +81,6 @@
   ],
   "start_datetime": "2021-10-22T00:00:00Z",
   "end_datetime": "2022-12-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.019110Z",
   "title": "Advancing the Study of Extreme Weather Events with Data, Deep Learning Methods and Climate Analysis",
   "extent": {

--- a/projects/aeolus-innovation-aeurs-expro-lidar-measurements-to-identify-streamers-and-analyze-atmospheric-waves-lisa/collection.json
+++ b/projects/aeolus-innovation-aeurs-expro-lidar-measurements-to-identify-streamers-and-analyze-atmospheric-waves-lisa/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2020-11-30T00:00:00Z",
   "end_datetime": "2021-02-07T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.025110Z",
   "title": "AEOLUS+inno - LISA",
   "extent": {

--- a/projects/aeolus-innovation-aeurs-expro-ocean-surface-wind-from-aeolus-sea-surface-returns-sea-flect/collection.json
+++ b/projects/aeolus-innovation-aeurs-expro-ocean-surface-wind-from-aeolus-sea-surface-returns-sea-flect/collection.json
@@ -92,7 +92,6 @@
   ],
   "start_datetime": "2020-11-11T00:00:00Z",
   "end_datetime": "2021-06-22T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.997110Z",
   "title": "AEOLUS+inno - SEA-FLECT",
   "extent": {

--- a/projects/aeolus-innovation-cdom-proxy-retrieval-from-aeolus-observations-color/collection.json
+++ b/projects/aeolus-innovation-cdom-proxy-retrieval-from-aeolus-observations-color/collection.json
@@ -122,7 +122,6 @@
   ],
   "start_datetime": "2021-01-02T00:00:00Z",
   "end_datetime": "2022-08-15T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.035110Z",
   "title": "AEOLUS+inno - COLOR",
   "extent": {

--- a/projects/aeolus-innovation-expro-improving-dust-monitoring-and-forecasting-through-aeolus-wind-data-assimilation-newton/collection.json
+++ b/projects/aeolus-innovation-expro-improving-dust-monitoring-and-forecasting-through-aeolus-wind-data-assimilation-newton/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2020-12-10T00:00:00Z",
   "end_datetime": "2022-05-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.003110Z",
   "title": "AEOLUS+inno - NEWTON",
   "extent": {

--- a/projects/aeolus-innovation-expro-lidar-measurements-to-identify-streamers-and-analyze-atmospheric-waves-lisa/collection.json
+++ b/projects/aeolus-innovation-expro-lidar-measurements-to-identify-streamers-and-analyze-atmospheric-waves-lisa/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2020-11-30T00:00:00Z",
   "end_datetime": "2021-02-07T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.012110Z",
   "title": "AEOLUS+inno - LISA",
   "extent": {

--- a/projects/aeolus-innovation-expro-ocean-sub-surface-products-and-applications/collection.json
+++ b/projects/aeolus-innovation-expro-ocean-sub-surface-products-and-applications/collection.json
@@ -92,7 +92,6 @@
   ],
   "start_datetime": "2020-09-12T00:00:00Z",
   "end_datetime": "2021-06-27T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.014110Z",
   "title": "AEOLUS+inno - AOC",
   "extent": {

--- a/projects/aeolus-innovation-expro-ocean-surface-wind-from-aeolus-sea-surface-returns-sea-flect/collection.json
+++ b/projects/aeolus-innovation-expro-ocean-surface-wind-from-aeolus-sea-surface-returns-sea-flect/collection.json
@@ -92,7 +92,6 @@
   ],
   "start_datetime": "2020-11-11T00:00:00Z",
   "end_datetime": "2021-06-22T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.981110Z",
   "title": "AEOLUS+inno - SEA-FLECT",
   "extent": {

--- a/projects/aeolus-innovation-studies-on-wind-and-aerosol-information-from-lidar-surface-returns-swails/collection.json
+++ b/projects/aeolus-innovation-studies-on-wind-and-aerosol-information-from-lidar-surface-returns-swails/collection.json
@@ -92,7 +92,6 @@
   ],
   "start_datetime": "2020-10-11T00:00:00Z",
   "end_datetime": "2021-06-21T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.987110Z",
   "title": "AEOLUS+inno - SWAILS+",
   "extent": {

--- a/projects/ai-enhanced-uncertainty-quantification-of-satellite-derived-hydroclimatic-extremes-extraim/collection.json
+++ b/projects/ai-enhanced-uncertainty-quantification-of-satellite-derived-hydroclimatic-extremes-extraim/collection.json
@@ -101,7 +101,6 @@
   ],
   "start_datetime": "2022-09-28T00:00:00Z",
   "end_datetime": "2024-04-01T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.993110Z",
   "title": "extrAIM",
   "extent": {

--- a/projects/ai4drought/collection.json
+++ b/projects/ai4drought/collection.json
@@ -89,7 +89,6 @@
   ],
   "start_datetime": "2021-12-14T00:00:00Z",
   "end_datetime": "2023-10-01T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.020110Z",
   "title": "AI4DROUGHT",
   "extent": {

--- a/projects/ai4dte-software-stack/collection.json
+++ b/projects/ai4dte-software-stack/collection.json
@@ -120,7 +120,6 @@
   ],
   "start_datetime": "2021-12-20T00:00:00Z",
   "end_datetime": "2023-01-03T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.005110Z",
   "title": "AI4DTE SW stack",
   "extent": {

--- a/projects/ai4dte/collection.json
+++ b/projects/ai4dte/collection.json
@@ -90,7 +90,6 @@
   ],
   "start_datetime": "2021-12-13T00:00:00Z",
   "end_datetime": "2023-01-15T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.987110Z",
   "title": "AI4DTE",
   "extent": {

--- a/projects/akross-altimetric-ku-band-radar-observations-simulated-with-smrt/collection.json
+++ b/projects/akross-altimetric-ku-band-radar-observations-simulated-with-smrt/collection.json
@@ -95,7 +95,6 @@
   ],
   "start_datetime": "2020-02-17T00:00:00Z",
   "end_datetime": "2021-01-10T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.983110Z",
   "title": "AKROSS",
   "extent": {

--- a/projects/albatross-altimetry-for-bathymetry-and-tideretrievals-for-the-southern-ocean-sea-ice-and-ice-shelves/collection.json
+++ b/projects/albatross-altimetry-for-bathymetry-and-tideretrievals-for-the-southern-ocean-sea-ice-and-ice-shelves/collection.json
@@ -125,7 +125,6 @@
   ],
   "start_datetime": "2021-01-05T00:00:00Z",
   "end_datetime": "2023-01-05T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.022110Z",
   "title": "ALBATROSS",
   "extent": {

--- a/projects/albiom-altimetry-for-biomass/collection.json
+++ b/projects/albiom-altimetry-for-biomass/collection.json
@@ -95,7 +95,6 @@
   ],
   "start_datetime": "2019-10-16T00:00:00Z",
   "end_datetime": "2020-06-11T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.011110Z",
   "title": "ALBIOM",
   "extent": {

--- a/projects/alpglacier/collection.json
+++ b/projects/alpglacier/collection.json
@@ -137,7 +137,6 @@
   ],
   "start_datetime": "2020-07-12T00:00:00Z",
   "end_datetime": "2021-06-25T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.981110Z",
   "title": "AlpGlacier",
   "extent": {

--- a/projects/alplakes/collection.json
+++ b/projects/alplakes/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2022-01-20T00:00:00Z",
   "end_datetime": "2023-03-15T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.019110Z",
   "title": "AlpLakes",
   "extent": {

--- a/projects/alpsnow/collection.json
+++ b/projects/alpsnow/collection.json
@@ -161,7 +161,6 @@
   ],
   "start_datetime": "2020-10-20T00:00:00Z",
   "end_datetime": "2022-01-12T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.020110Z",
   "title": "AlpSnow",
   "extent": {

--- a/projects/ampac-esa-networking-action/collection.json
+++ b/projects/ampac-esa-networking-action/collection.json
@@ -128,7 +128,6 @@
   ],
   "start_datetime": "2021-12-13T00:00:00Z",
   "end_datetime": "2023-01-04T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.999110Z",
   "title": "AMPAC-Net",
   "extent": {

--- a/projects/anreo-retrieval-of-total-ozone-using-olci-s-3-over-antarctica/collection.json
+++ b/projects/anreo-retrieval-of-total-ozone-using-olci-s-3-over-antarctica/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2020-03-25T00:00:00Z",
   "end_datetime": "2021-05-07T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.014110Z",
   "title": "AnREO",
   "extent": {

--- a/projects/arctic-salinity/collection.json
+++ b/projects/arctic-salinity/collection.json
@@ -110,7 +110,6 @@
   ],
   "start_datetime": "2018-10-16T00:00:00Z",
   "end_datetime": "2020-04-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.004110Z",
   "title": "Arctic + Salinity",
   "extent": {

--- a/projects/arctic-snow-on-sea-ice/collection.json
+++ b/projects/arctic-snow-on-sea-ice/collection.json
@@ -101,7 +101,6 @@
   ],
   "start_datetime": "2016-12-07T00:00:00Z",
   "end_datetime": "2018-09-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.986110Z",
   "title": "Arctic+Snow on Sea Ice",
   "extent": {

--- a/projects/arctic-theme-3-aeur-fresh-water-fluxes/collection.json
+++ b/projects/arctic-theme-3-aeur-fresh-water-fluxes/collection.json
@@ -89,7 +89,6 @@
   ],
   "start_datetime": "2016-06-25T00:00:00Z",
   "end_datetime": "2018-01-03T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.983110Z",
   "title": "ArcFlux",
   "extent": {

--- a/projects/arctic-theme-3-fresh-water-fluxes/collection.json
+++ b/projects/arctic-theme-3-fresh-water-fluxes/collection.json
@@ -95,7 +95,6 @@
   ],
   "start_datetime": "2016-06-25T00:00:00Z",
   "end_datetime": "2018-01-03T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.004110Z",
   "title": "ArcFlux",
   "extent": {

--- a/projects/arcticsummit-arctic-summer-ice-thickness/collection.json
+++ b/projects/arcticsummit-arctic-summer-ice-thickness/collection.json
@@ -89,7 +89,6 @@
   ],
   "start_datetime": "2018-10-16T00:00:00Z",
   "end_datetime": "2020-10-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.034110Z",
   "title": "(LPF) ArcticSummIT",
   "extent": {

--- a/projects/arktalas-hoavva-project/collection.json
+++ b/projects/arktalas-hoavva-project/collection.json
@@ -104,7 +104,6 @@
   ],
   "start_datetime": "2019-05-16T00:00:00Z",
   "end_datetime": "2021-07-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.035110Z",
   "title": "ARKATLAS",
   "extent": {

--- a/projects/assessing-cryosphere-biosphere-linkages-with-earth-observations-in-northern-high-latitudes-cryobiolinks/collection.json
+++ b/projects/assessing-cryosphere-biosphere-linkages-with-earth-observations-in-northern-high-latitudes-cryobiolinks/collection.json
@@ -72,7 +72,6 @@
   ],
   "start_datetime": "2022-02-02T00:00:00Z",
   "end_datetime": "2023-01-04T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.993110Z",
   "title": "CRYOBIOLINKS",
   "extent": {

--- a/projects/baltic-geodetic-sar-for-baltic-height-system-unification-sar-hsu/collection.json
+++ b/projects/baltic-geodetic-sar-for-baltic-height-system-unification-sar-hsu/collection.json
@@ -197,7 +197,6 @@
   ],
   "start_datetime": "2019-05-03T00:00:00Z",
   "end_datetime": "2020-10-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.001110Z",
   "title": "SAR-HSU",
   "extent": {

--- a/projects/baltic-reconstruction-of-the-sea-level/collection.json
+++ b/projects/baltic-reconstruction-of-the-sea-level/collection.json
@@ -101,7 +101,6 @@
   ],
   "start_datetime": "2019-01-01T00:00:00Z",
   "end_datetime": "2021-01-01T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.992110Z",
   "title": "Baltic+ Sea Level",
   "extent": {

--- a/projects/baltic-salinity-dynamics/collection.json
+++ b/projects/baltic-salinity-dynamics/collection.json
@@ -101,7 +101,6 @@
   ],
   "start_datetime": "2018-04-12T00:00:00Z",
   "end_datetime": "2019-08-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.995110Z",
   "title": "BALTIC+ Salinity Dynamics",
   "extent": {

--- a/projects/baltic-sea-land-biogeochemical-linkages-sealabio/collection.json
+++ b/projects/baltic-sea-land-biogeochemical-linkages-sealabio/collection.json
@@ -128,7 +128,6 @@
   ],
   "start_datetime": "2018-12-14T00:00:00Z",
   "end_datetime": "2020-05-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.013110Z",
   "title": "BALTIC+ Sea-Land",
   "extent": {

--- a/projects/baltic-seal-sea-level/collection.json
+++ b/projects/baltic-seal-sea-level/collection.json
@@ -125,7 +125,6 @@
   ],
   "start_datetime": "2019-06-02T00:00:00Z",
   "end_datetime": "2020-09-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.020110Z",
   "title": "BALTIC+ SEAL - Sea Level",
   "extent": {

--- a/projects/bathysent-an-innovative-method-to-retrieve-global-coastal-bathymetry-from-sentinel-2/collection.json
+++ b/projects/bathysent-an-innovative-method-to-retrieve-global-coastal-bathymetry-from-sentinel-2/collection.json
@@ -89,7 +89,6 @@
   ],
   "start_datetime": "2018-07-05T00:00:00Z",
   "end_datetime": "2019-06-15T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.988110Z",
   "title": "BathySent",
   "extent": {

--- a/projects/biodiversity-precursors-coastal/collection.json
+++ b/projects/biodiversity-precursors-coastal/collection.json
@@ -90,7 +90,6 @@
   ],
   "start_datetime": "2021-10-14T00:00:00Z",
   "end_datetime": "2023-10-14T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.989110Z",
   "title": "BiCOME",
   "extent": {

--- a/projects/biodiversity-precursors-expro-theme-1-terrestrial-earth-observation-for-biodiversity-modelling-eo4diversity/collection.json
+++ b/projects/biodiversity-precursors-expro-theme-1-terrestrial-earth-observation-for-biodiversity-modelling-eo4diversity/collection.json
@@ -113,7 +113,6 @@
   ],
   "start_datetime": "2022-01-08T00:00:00Z",
   "end_datetime": "2023-12-07T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.017110Z",
   "title": "EO4Diversity",
   "extent": {

--- a/projects/biodiversity-precursors-expro-theme-2-freshwater-biomondo/collection.json
+++ b/projects/biodiversity-precursors-expro-theme-2-freshwater-biomondo/collection.json
@@ -95,7 +95,6 @@
   ],
   "start_datetime": "2022-07-21T00:00:00Z",
   "end_datetime": "2023-01-09T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.006110Z",
   "title": "BIOMONDO",
   "extent": {

--- a/projects/biological-pump-and-carbon-exchange-processes/collection.json
+++ b/projects/biological-pump-and-carbon-exchange-processes/collection.json
@@ -227,7 +227,6 @@
   ],
   "start_datetime": "2019-09-12T00:00:00Z",
   "end_datetime": "2023-08-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.030110Z",
   "title": "BICEP",
   "extent": {

--- a/projects/biomap/collection.json
+++ b/projects/biomap/collection.json
@@ -72,7 +72,6 @@
   ],
   "start_datetime": "2021-09-22T00:00:00Z",
   "end_datetime": "2023-01-09T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.010110Z",
   "title": "BiomAP",
   "extent": {

--- a/projects/biomascat-assessing-vegetation-carbon-dynamics-from-multi-decadal-spaceborne-observations/collection.json
+++ b/projects/biomascat-assessing-vegetation-carbon-dynamics-from-multi-decadal-spaceborne-observations/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2018-05-09T00:00:00Z",
   "end_datetime": "2021-12-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.985110Z",
   "title": "BIOMASCAT",
   "extent": {

--- a/projects/cassis-climate-altimetric-studies-with-sea-ice-and-snow/collection.json
+++ b/projects/cassis-climate-altimetric-studies-with-sea-ice-and-snow/collection.json
@@ -107,7 +107,6 @@
   ],
   "start_datetime": "2020-01-11T00:00:00Z",
   "end_datetime": "2022-10-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.002110Z",
   "title": "(LPF) CASSIS",
   "extent": {

--- a/projects/citysatair/collection.json
+++ b/projects/citysatair/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2020-01-07T00:00:00Z",
   "end_datetime": "2021-07-15T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.989110Z",
   "title": "CITYSATAIR",
   "extent": {

--- a/projects/climate-data-record-of-stratospheric-aerosols-crest/collection.json
+++ b/projects/climate-data-record-of-stratospheric-aerosols-crest/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2020-06-23T00:00:00Z",
   "end_datetime": "2021-05-25T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.029110Z",
   "title": "CREST",
   "extent": {

--- a/projects/consistent-retrieval-of-cloud-aerosol-surface/collection.json
+++ b/projects/consistent-retrieval-of-cloud-aerosol-surface/collection.json
@@ -101,7 +101,6 @@
   ],
   "start_datetime": "2017-07-17T00:00:00Z",
   "end_datetime": "2019-02-10T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.031110Z",
   "title": "CIRCAS",
   "extent": {

--- a/projects/contribution-of-swarm-data-to-the-prompt-detection-of-tsunamis-and-other-natural-hazards-costo/collection.json
+++ b/projects/contribution-of-swarm-data-to-the-prompt-detection-of-tsunamis-and-other-natural-hazards-costo/collection.json
@@ -110,7 +110,6 @@
   ],
   "start_datetime": "2019-02-22T00:00:00Z",
   "end_datetime": "2020-10-28T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.021110Z",
   "title": "COSTO",
   "extent": {

--- a/projects/cryosat-antarctic-ocean/collection.json
+++ b/projects/cryosat-antarctic-ocean/collection.json
@@ -113,7 +113,6 @@
   ],
   "start_datetime": "2018-12-21T00:00:00Z",
   "end_datetime": "2021-04-01T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.998110Z",
   "title": "Cryosat+ Antarctic Ocean",
   "extent": {

--- a/projects/cryosat-mountain-glaciers/collection.json
+++ b/projects/cryosat-mountain-glaciers/collection.json
@@ -107,7 +107,6 @@
   ],
   "start_datetime": "2015-05-13T00:00:00Z",
   "end_datetime": "2020-12-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.004110Z",
   "title": "CryoSat+ Mountain Glaciers",
   "extent": {

--- a/projects/cryosat-plus-for-oceans-cp4o/collection.json
+++ b/projects/cryosat-plus-for-oceans-cp4o/collection.json
@@ -188,7 +188,6 @@
   ],
   "start_datetime": "2012-05-06T00:00:00Z",
   "end_datetime": "2018-05-15T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.036110Z",
   "title": "CryoSat+ Oceans",
   "extent": {

--- a/projects/cryosmos/collection.json
+++ b/projects/cryosmos/collection.json
@@ -131,7 +131,6 @@
   ],
   "start_datetime": "2014-09-23T00:00:00Z",
   "end_datetime": "2017-10-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.998110Z",
   "title": "CryoSMOS",
   "extent": {

--- a/projects/cryosphere-virtual-laboratory-expro/collection.json
+++ b/projects/cryosphere-virtual-laboratory-expro/collection.json
@@ -107,7 +107,6 @@
   ],
   "start_datetime": "2019-10-15T00:00:00Z",
   "end_datetime": "2022-11-15T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.995110Z",
   "title": "CVL",
   "extent": {

--- a/projects/cryotop-evolution/collection.json
+++ b/projects/cryotop-evolution/collection.json
@@ -191,7 +191,6 @@
   ],
   "start_datetime": "2016-03-03T00:00:00Z",
   "end_datetime": "2019-11-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.036110Z",
   "title": "CryoTop Evolution",
   "extent": {

--- a/projects/deep-earth-system-data-lab/collection.json
+++ b/projects/deep-earth-system-data-lab/collection.json
@@ -125,7 +125,6 @@
   ],
   "start_datetime": "2022-04-01T00:00:00Z",
   "end_datetime": "2025-12-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.996110Z",
   "title": "DeepESDL",
   "extent": {

--- a/projects/deep-extremes/collection.json
+++ b/projects/deep-extremes/collection.json
@@ -110,7 +110,6 @@
   ],
   "start_datetime": "2022-04-08T00:00:00Z",
   "end_datetime": "2023-09-09T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.032110Z",
   "title": "DEEP EXTREMES",
   "extent": {

--- a/projects/demonstrator-precursor-digital-assistant-interface-for-digital-twin-earth-da4dte/collection.json
+++ b/projects/demonstrator-precursor-digital-assistant-interface-for-digital-twin-earth-da4dte/collection.json
@@ -92,7 +92,6 @@
   ],
   "start_datetime": "2022-07-26T00:00:00Z",
   "end_datetime": "2023-09-23T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.034110Z",
   "title": "DA4DTE",
   "extent": {

--- a/projects/detection-and-threats-of-marine-heat-waves-careheat/collection.json
+++ b/projects/detection-and-threats-of-marine-heat-waves-careheat/collection.json
@@ -107,7 +107,6 @@
   ],
   "start_datetime": "2022-01-02T00:00:00Z",
   "end_datetime": "2024-01-02T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.002110Z",
   "title": "CareHEAT",
   "extent": {

--- a/projects/detection-of-anthropogenic-co2-emissions-sources/collection.json
+++ b/projects/detection-of-anthropogenic-co2-emissions-sources/collection.json
@@ -77,7 +77,6 @@
   ],
   "start_datetime": "2018-10-30T00:00:00Z",
   "end_datetime": "2020-05-27T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.006110Z",
   "title": "DACES",
   "extent": {

--- a/projects/development-and-interpretation-of-improved-nitrous-acid-retrievals-project-dinar/collection.json
+++ b/projects/development-and-interpretation-of-improved-nitrous-acid-retrievals-project-dinar/collection.json
@@ -77,7 +77,6 @@
   ],
   "start_datetime": "2021-10-09T00:00:00Z",
   "end_datetime": "2023-01-10T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.996110Z",
   "title": "DINAR",
   "extent": {

--- a/projects/development-of-pan-european-multi-sensor-snow-mapping-methods-exploiting-sentinel-1/collection.json
+++ b/projects/development-of-pan-european-multi-sensor-snow-mapping-methods-exploiting-sentinel-1/collection.json
@@ -107,7 +107,6 @@
   ],
   "start_datetime": "2016-10-20T00:00:00Z",
   "end_datetime": "2019-01-02T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.032110Z",
   "title": "S14Science: Snow",
   "extent": {

--- a/projects/dynamic-topography-and-satellite-gravity-data-joint-inversion-using-reduced-order-models-dygiro/collection.json
+++ b/projects/dynamic-topography-and-satellite-gravity-data-joint-inversion-using-reduced-order-models-dygiro/collection.json
@@ -72,7 +72,6 @@
   ],
   "start_datetime": "2021-10-09T00:00:00Z",
   "end_datetime": "2023-02-10T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.010110Z",
   "title": "DYGIRO",
   "extent": {

--- a/projects/earth-observation-advanced-science-tools-for-sea-level-extreme-events-eoatsee/collection.json
+++ b/projects/earth-observation-advanced-science-tools-for-sea-level-extreme-events-eoatsee/collection.json
@@ -119,7 +119,6 @@
   ],
   "start_datetime": "2021-07-09T00:00:00Z",
   "end_datetime": "2023-02-10T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.988110Z",
   "title": "EOatSEE",
   "extent": {

--- a/projects/earth-observation-data-for-science-and-innovation-in-the-black-sea/collection.json
+++ b/projects/earth-observation-data-for-science-and-innovation-in-the-black-sea/collection.json
@@ -203,7 +203,6 @@
   ],
   "start_datetime": "2019-04-26T00:00:00Z",
   "end_datetime": "2021-03-05T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.996110Z",
   "title": "EO4SIBS",
   "extent": {

--- a/projects/earth-observation-for-surface-mass-balance-eo4smb/collection.json
+++ b/projects/earth-observation-for-surface-mass-balance-eo4smb/collection.json
@@ -101,7 +101,6 @@
   ],
   "start_datetime": "2020-08-27T00:00:00Z",
   "end_datetime": "2022-08-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.997110Z",
   "title": "EO4SMB",
   "extent": {

--- a/projects/earth-system-data-lab-esdl/collection.json
+++ b/projects/earth-system-data-lab-esdl/collection.json
@@ -137,7 +137,6 @@
   ],
   "start_datetime": "2018-01-05T00:00:00Z",
   "end_datetime": "2020-12-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.996110Z",
   "title": "ESDL",
   "extent": {

--- a/projects/eocytes-evaluation-of-the-effect-of-ozone-on-crop-yields-and-the-terrestrial-carbon-pool-using-satellite-data/collection.json
+++ b/projects/eocytes-evaluation-of-the-effect-of-ozone-on-crop-yields-and-the-terrestrial-carbon-pool-using-satellite-data/collection.json
@@ -77,7 +77,6 @@
   ],
   "start_datetime": "2018-10-17T00:00:00Z",
   "end_datetime": "2020-10-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.016110Z",
   "title": "(LPF) EOCYTES",
   "extent": {

--- a/projects/eoplumes/collection.json
+++ b/projects/eoplumes/collection.json
@@ -72,7 +72,6 @@
   ],
   "start_datetime": "2021-09-17T00:00:00Z",
   "end_datetime": "2023-05-10T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.000110Z",
   "title": "EOplumes",
   "extent": {

--- a/projects/esa-science-hub-florian-le-guillou/collection.json
+++ b/projects/esa-science-hub-florian-le-guillou/collection.json
@@ -86,7 +86,6 @@
   ],
   "start_datetime": "2023-07-20T00:00:00Z",
   "end_datetime": "2024-05-01T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.999110Z",
   "title": "ESA Science Hub-Florian Le Guillou",
   "extent": {

--- a/projects/examining-greenland-s-ice-marginal-lakes-under-a-changing-climate-griml/collection.json
+++ b/projects/examining-greenland-s-ice-marginal-lakes-under-a-changing-climate-griml/collection.json
@@ -78,7 +78,6 @@
   ],
   "start_datetime": "2021-10-11T00:00:00Z",
   "end_datetime": "2025-01-06T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-11-08T09:45:00Z",
   "title": "(LPF) GRIML",
   "extent": {

--- a/projects/experimental-joint-inversion/collection.json
+++ b/projects/experimental-joint-inversion/collection.json
@@ -77,7 +77,6 @@
   ],
   "start_datetime": "2022-07-04T00:00:00Z",
   "end_datetime": "2023-12-19T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.001110Z",
   "title": "XORN",
   "extent": {

--- a/projects/explainable-ai-application-to-trustworthy-super-resolution-opensr-a/collection.json
+++ b/projects/explainable-ai-application-to-trustworthy-super-resolution-opensr-a/collection.json
@@ -96,7 +96,6 @@
   ],
   "start_datetime": "2022-02-01T00:00:00Z",
   "end_datetime": "2023-12-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.990110Z",
   "title": "OpenSR",
   "extent": {

--- a/projects/explainable-ai-application-to-trustworthy-super-resolution-opensr/collection.json
+++ b/projects/explainable-ai-application-to-trustworthy-super-resolution-opensr/collection.json
@@ -96,7 +96,6 @@
   ],
   "start_datetime": "2022-02-01T00:00:00Z",
   "end_datetime": "2023-12-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.003110Z",
   "title": "OpenSR",
   "extent": {

--- a/projects/ffsar-coastal-fully-focused-sar-altimetry-and-innovative-river-level-gauges-for-coastal-monitoring/collection.json
+++ b/projects/ffsar-coastal-fully-focused-sar-altimetry-and-innovative-river-level-gauges-for-coastal-monitoring/collection.json
@@ -95,7 +95,6 @@
   ],
   "start_datetime": "2021-11-11T00:00:00Z",
   "end_datetime": "2024-06-01T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.012110Z",
   "title": "FFSAR - Coastal",
   "extent": {

--- a/projects/fluvial-video-from-satellite-fluvisat/collection.json
+++ b/projects/fluvial-video-from-satellite-fluvisat/collection.json
@@ -77,7 +77,6 @@
   ],
   "start_datetime": "2022-11-21T00:00:00Z",
   "end_datetime": "2024-01-15T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.991110Z",
   "title": "FluViSat",
   "extent": {

--- a/projects/forestscan/collection.json
+++ b/projects/forestscan/collection.json
@@ -113,7 +113,6 @@
   ],
   "start_datetime": "2019-08-03T00:00:00Z",
   "end_datetime": "2021-06-19T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.994110Z",
   "title": "ForestScan",
   "extent": {

--- a/projects/glaciers-mass-balance-intercomparison-exercise-glambie/collection.json
+++ b/projects/glaciers-mass-balance-intercomparison-exercise-glambie/collection.json
@@ -72,7 +72,6 @@
   ],
   "start_datetime": "2022-01-14T00:00:00Z",
   "end_datetime": "2024-12-02T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.999110Z",
   "title": "GLAMBIE",
   "extent": {

--- a/projects/goce-antarctica/collection.json
+++ b/projects/goce-antarctica/collection.json
@@ -110,7 +110,6 @@
   ],
   "start_datetime": "2015-08-20T00:00:00Z",
   "end_datetime": "2019-06-25T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.024110Z",
   "title": "GOCE+ ANTARCTICA",
   "extent": {

--- a/projects/godae-ocean-observing-system-evaluation-of-satellite-sea-surface-salinity-and-el-nino-2015-smos-nino15/collection.json
+++ b/projects/godae-ocean-observing-system-evaluation-of-satellite-sea-surface-salinity-and-el-nino-2015-smos-nino15/collection.json
@@ -95,7 +95,6 @@
   ],
   "start_datetime": "2016-07-27T00:00:00Z",
   "end_datetime": "2019-05-15T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.027110Z",
   "title": "SMOS-NINO 2015",
   "extent": {

--- a/projects/ground-deformation-from-meteorological-seismic-and-anthropogenic-changes-analysed-by-remote-sensing-geomatic-experiments-and-extended-reality-germane/collection.json
+++ b/projects/ground-deformation-from-meteorological-seismic-and-anthropogenic-changes-analysed-by-remote-sensing-geomatic-experiments-and-extended-reality-germane/collection.json
@@ -77,7 +77,6 @@
   ],
   "start_datetime": "2023-01-18T00:00:00Z",
   "end_datetime": "2024-02-20T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.015110Z",
   "title": "(LPF) GERMANE",
   "extent": {

--- a/projects/hafelekar-line-of-side-aq-monitoring-karlos/collection.json
+++ b/projects/hafelekar-line-of-side-aq-monitoring-karlos/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2022-08-04T00:00:00Z",
   "end_datetime": "2024-04-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.029110Z",
   "title": "KARLOS",
   "extent": {

--- a/projects/handling-of-3d-clouds-in-trace-gas-retrievals-3dctrl/collection.json
+++ b/projects/handling-of-3d-clouds-in-trace-gas-retrievals-3dctrl/collection.json
@@ -95,7 +95,6 @@
   ],
   "start_datetime": "2022-04-29T00:00:00Z",
   "end_datetime": "2024-05-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.007110Z",
   "title": "3DCTRL",
   "extent": {

--- a/projects/high-information-content-ozone-profile-algorithm-for-ground-based-passive-remote-sensing-instruments-opa/collection.json
+++ b/projects/high-information-content-ozone-profile-algorithm-for-ground-based-passive-remote-sensing-instruments-opa/collection.json
@@ -72,7 +72,6 @@
   ],
   "start_datetime": "2022-01-14T00:00:00Z",
   "end_datetime": "2024-03-15T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.013110Z",
   "title": "OPA",
   "extent": {

--- a/projects/high-latitude-poynting-flux-into-and-out-of-the-atmosphere-swarm-superdarn-and-ampere-observations-hlpf-ssa/collection.json
+++ b/projects/high-latitude-poynting-flux-into-and-out-of-the-atmosphere-swarm-superdarn-and-ampere-observations-hlpf-ssa/collection.json
@@ -72,7 +72,6 @@
   ],
   "start_datetime": "2022-09-15T00:00:00Z",
   "end_datetime": "2024-01-04T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.012110Z",
   "title": "HLPF-SSA",
   "extent": {

--- a/projects/hr-albedomap-generation-of-high-resolution-spectral-and-broadband-surface-albedo-products-based-on-sentinel-2-msi-measurements/collection.json
+++ b/projects/hr-albedomap-generation-of-high-resolution-spectral-and-broadband-surface-albedo-products-based-on-sentinel-2-msi-measurements/collection.json
@@ -77,7 +77,6 @@
   ],
   "start_datetime": "2020-03-25T00:00:00Z",
   "end_datetime": "2021-10-07T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.008110Z",
   "title": "HR-AlbedoMap",
   "extent": {

--- a/projects/hydrocoastal-coastal-ocean-and-inland-water-altimetry/collection.json
+++ b/projects/hydrocoastal-coastal-ocean-and-inland-water-altimetry/collection.json
@@ -176,7 +176,6 @@
   ],
   "start_datetime": "2020-01-28T00:00:00Z",
   "end_datetime": "2022-02-18T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.023110Z",
   "title": "HydroCoastal",
   "extent": {

--- a/projects/iceflow-short-term-movements-in-the-cryosphere/collection.json
+++ b/projects/iceflow-short-term-movements-in-the-cryosphere/collection.json
@@ -77,7 +77,6 @@
   ],
   "start_datetime": "2018-11-10T00:00:00Z",
   "end_datetime": "2020-11-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.008110Z",
   "title": "(LPF) ICEFLOW",
   "extent": {

--- a/projects/impact-study-of-covid-19-lockdown-measures-on-air-quality-and-climate-icovac/collection.json
+++ b/projects/impact-study-of-covid-19-lockdown-measures-on-air-quality-and-climate-icovac/collection.json
@@ -95,7 +95,6 @@
   ],
   "start_datetime": "2020-04-29T00:00:00Z",
   "end_datetime": "2021-06-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.031110Z",
   "title": "ICOVAC",
   "extent": {

--- a/projects/introducing-machine-learning-into-targeted-analysis-for-terrestrial-ecosystems-imitate/collection.json
+++ b/projects/introducing-machine-learning-into-targeted-analysis-for-terrestrial-ecosystems-imitate/collection.json
@@ -77,7 +77,6 @@
   ],
   "start_datetime": "2022-11-03T00:00:00Z",
   "end_datetime": "2024-01-04T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.037110Z",
   "title": "IMITATE",
   "extent": {

--- a/projects/investigating-lightning-generated-elf-whistlers-to-improve-ionospheric-models-ilgew/collection.json
+++ b/projects/investigating-lightning-generated-elf-whistlers-to-improve-ionospheric-models-ilgew/collection.json
@@ -104,7 +104,6 @@
   ],
   "start_datetime": "2019-02-22T00:00:00Z",
   "end_datetime": "2020-10-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.983110Z",
   "title": "ILGEW",
   "extent": {

--- a/projects/irrigation/collection.json
+++ b/projects/irrigation/collection.json
@@ -131,7 +131,6 @@
   ],
   "start_datetime": "2020-01-03T00:00:00Z",
   "end_datetime": "2022-10-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.016110Z",
   "title": "Irrigation+",
   "extent": {

--- a/projects/l2a-rut/collection.json
+++ b/projects/l2a-rut/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2020-05-20T00:00:00Z",
   "end_datetime": "2022-01-07T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.028110Z",
   "title": "(LPF) L2A-RUT",
   "extent": {

--- a/projects/l2a/collection.json
+++ b/projects/l2a/collection.json
@@ -78,7 +78,6 @@
   ],
   "start_datetime": "2022-06-04T00:00:00Z",
   "end_datetime": "2024-04-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.005110Z",
   "title": "L2A+",
   "extent": {

--- a/projects/land-surface-carbon-constellation-study/collection.json
+++ b/projects/land-surface-carbon-constellation-study/collection.json
@@ -149,7 +149,6 @@
   ],
   "start_datetime": "2020-08-07T00:00:00Z",
   "end_datetime": "2023-04-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.984110Z",
   "title": "Carbon Constellation",
   "extent": {

--- a/projects/lidar-climatology-of-vertical-aerosol-structure-for-space-based-lidar-simulation-studies-livas/collection.json
+++ b/projects/lidar-climatology-of-vertical-aerosol-structure-for-space-based-lidar-simulation-studies-livas/collection.json
@@ -180,7 +180,6 @@
   ],
   "start_datetime": "2011-01-01T00:00:00Z",
   "end_datetime": "2013-12-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.009110Z",
   "title": "LIVAS",
   "extent": {

--- a/projects/lidar-cloud-record-for-climate-licrec/collection.json
+++ b/projects/lidar-cloud-record-for-climate-licrec/collection.json
@@ -78,7 +78,6 @@
   ],
   "start_datetime": "2022-06-04T00:00:00Z",
   "end_datetime": "2024-04-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.005110Z",
   "title": "LICREC",
   "extent": {

--- a/projects/lpf-wise/collection.json
+++ b/projects/lpf-wise/collection.json
@@ -89,9 +89,6 @@
   ],
   "start_datetime": "2022-12-15T00:00:00Z",
   "end_datetime": "2025-02-28T00:00:00Z",
-  "osc:missions": [
-    "Sentinel-1"
-  ],
   "updated": "2025-24-01T09:45:00Z",
   "title": "(LPF) WISE",
   "extent": {

--- a/projects/mass-balance-and-ice-dynamics-of-antarctic-peninsula-glaciers-mit-ap/collection.json
+++ b/projects/mass-balance-and-ice-dynamics-of-antarctic-peninsula-glaciers-mit-ap/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2021-05-01T00:00:00Z",
   "end_datetime": "2024-06-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-11-13T20:32:22.992110Z",
   "title": "(LPF) MIT-AP",
   "extent": {

--- a/projects/mediterranean-sea-regional-initiative-land-based-pollution/collection.json
+++ b/projects/mediterranean-sea-regional-initiative-land-based-pollution/collection.json
@@ -114,7 +114,6 @@
   ],
   "start_datetime": "2021-09-03T00:00:00Z",
   "end_datetime": "2023-09-03T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.004110Z",
   "title": "MedEOS",
   "extent": {

--- a/projects/methane-emissions-in-the-northern-hemisphere-eo-data-and-global-atmospheric-methane-inversion-model-estimates/collection.json
+++ b/projects/methane-emissions-in-the-northern-hemisphere-eo-data-and-global-atmospheric-methane-inversion-model-estimates/collection.json
@@ -86,7 +86,6 @@
   ],
   "start_datetime": "2018-05-09T00:00:00Z",
   "end_datetime": "2022-01-04T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.017110Z",
   "title": "MethEO",
   "extent": {

--- a/projects/methane/collection.json
+++ b/projects/methane/collection.json
@@ -113,7 +113,6 @@
   ],
   "start_datetime": "2020-01-20T00:00:00Z",
   "end_datetime": "2022-02-20T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.023110Z",
   "title": "Methane+",
   "extent": {

--- a/projects/methanecamp/collection.json
+++ b/projects/methanecamp/collection.json
@@ -72,7 +72,6 @@
   ],
   "start_datetime": "2022-11-01T00:00:00Z",
   "end_datetime": "2024-02-07T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.024110Z",
   "title": "MethaneCAMP",
   "extent": {

--- a/projects/moheacan-monitoring-ocean-heat-content-and-earth-energy-imbalance-from-space/collection.json
+++ b/projects/moheacan-monitoring-ocean-heat-content-and-earth-energy-imbalance-from-space/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2019-12-18T00:00:00Z",
   "end_datetime": "2021-01-15T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.994110Z",
   "title": "MOHeaCAN",
   "extent": {

--- a/projects/multi-flex-towards-a-strategy-for-fluorescence-monitoring-at-multiple-scales-within-the-context-of-the-flex-s-3-tandem-mission/collection.json
+++ b/projects/multi-flex-towards-a-strategy-for-fluorescence-monitoring-at-multiple-scales-within-the-context-of-the-flex-s-3-tandem-mission/collection.json
@@ -77,7 +77,6 @@
   ],
   "start_datetime": "2018-02-10T00:00:00Z",
   "end_datetime": "2020-10-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.993110Z",
   "title": "(LPF) MULTI-FLEX",
   "extent": {

--- a/projects/novel-computational-methods-for-reliable-satellite-based-air-quality-data-noodlesalad/collection.json
+++ b/projects/novel-computational-methods-for-reliable-satellite-based-air-quality-data-noodlesalad/collection.json
@@ -72,7 +72,6 @@
   ],
   "start_datetime": "2022-08-04T00:00:00Z",
   "end_datetime": "2024-01-10T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.994110Z",
   "title": "NOODLESALAD",
   "extent": {

--- a/projects/ocean-circulation-from-ocean-colour-observations-circol/collection.json
+++ b/projects/ocean-circulation-from-ocean-colour-observations-circol/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2019-07-26T00:00:00Z",
   "end_datetime": "2021-01-05T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.000110Z",
   "title": "CIRCOL",
   "extent": {

--- a/projects/ocean-extreme/collection.json
+++ b/projects/ocean-extreme/collection.json
@@ -131,7 +131,6 @@
   ],
   "start_datetime": "2020-10-30T00:00:00Z",
   "end_datetime": "2022-01-12T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.993110Z",
   "title": "OCEAN+EXTREME",
   "extent": {

--- a/projects/ocean-health-ocean-acidification/collection.json
+++ b/projects/ocean-health-ocean-acidification/collection.json
@@ -101,7 +101,6 @@
   ],
   "start_datetime": "2022-01-02T00:00:00Z",
   "end_datetime": "2024-01-02T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.997110Z",
   "title": "Ocean-Health-OA",
   "extent": {

--- a/projects/ocean-health-open-ocean-biodiversity/collection.json
+++ b/projects/ocean-health-open-ocean-biodiversity/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2022-01-02T00:00:00Z",
   "end_datetime": "2024-01-02T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.990110Z",
   "title": "BOOMS",
   "extent": {

--- a/projects/ovalie-oceanic-intrinsic-variability-versus-atmospheric-forced-variability-of-sea-level-change/collection.json
+++ b/projects/ovalie-oceanic-intrinsic-variability-versus-atmospheric-forced-variability-of-sea-level-change/collection.json
@@ -89,7 +89,6 @@
   ],
   "start_datetime": "2018-10-17T00:00:00Z",
   "end_datetime": "2020-10-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.035110Z",
   "title": "(LPF) OVALIE",
   "extent": {

--- a/projects/ozone-recovery-from-merged-observational-data-and-model-analysis-oregano/collection.json
+++ b/projects/ozone-recovery-from-merged-observational-data-and-model-analysis-oregano/collection.json
@@ -89,7 +89,6 @@
   ],
   "start_datetime": "2022-11-29T00:00:00Z",
   "end_datetime": "2024-12-15T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.015110Z",
   "title": "OREGANO",
   "extent": {

--- a/projects/pass-swio/collection.json
+++ b/projects/pass-swio/collection.json
@@ -77,7 +77,6 @@
   ],
   "start_datetime": "2022-11-21T00:00:00Z",
   "end_datetime": "2024-12-15T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.987110Z",
   "title": "PASS-SWIO",
   "extent": {

--- a/projects/phab-iv-phase-based-sentinel-1-ice-velocity/collection.json
+++ b/projects/phab-iv-phase-based-sentinel-1-ice-velocity/collection.json
@@ -89,7 +89,6 @@
   ],
   "start_datetime": "2019-12-20T00:00:00Z",
   "end_datetime": "2021-02-15T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.001110Z",
   "title": "PHAB-IV",
   "extent": {

--- a/projects/photoproxy-technical-assistance-for-the-photosynthetic-proxy-experiment/collection.json
+++ b/projects/photoproxy-technical-assistance-for-the-photosynthetic-proxy-experiment/collection.json
@@ -95,7 +95,6 @@
   ],
   "start_datetime": "2018-10-30T00:00:00Z",
   "end_datetime": "2020-07-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.028110Z",
   "title": "PHOTOPROXY",
   "extent": {

--- a/projects/physioglob-assessing-the-inter-annual-physiological-response-of-phytoplankton-to-global-warming-using-long-term-satellite-observations/collection.json
+++ b/projects/physioglob-assessing-the-inter-annual-physiological-response-of-phytoplankton-to-global-warming-using-long-term-satellite-observations/collection.json
@@ -89,7 +89,6 @@
   ],
   "start_datetime": "2018-01-10T00:00:00Z",
   "end_datetime": "2020-10-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.029110Z",
   "title": "(LPF) PHYSIOGLOB",
   "extent": {

--- a/projects/phytoplankton-and-fisheries-under-regional-warming-in-the-global-oceans-poseidon/collection.json
+++ b/projects/phytoplankton-and-fisheries-under-regional-warming-in-the-global-oceans-poseidon/collection.json
@@ -72,7 +72,6 @@
   ],
   "start_datetime": "2022-11-22T00:00:00Z",
   "end_datetime": "2024-12-15T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.021110Z",
   "title": "POSEIDON",
   "extent": {

--- a/projects/polar-ice-shelf/collection.json
+++ b/projects/polar-ice-shelf/collection.json
@@ -119,7 +119,6 @@
   ],
   "start_datetime": "2020-03-09T00:00:00Z",
   "end_datetime": "2022-08-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.982110Z",
   "title": "Polar+ Ice Shelves",
   "extent": {

--- a/projects/polar-low-detection-from-s-1-data/collection.json
+++ b/projects/polar-low-detection-from-s-1-data/collection.json
@@ -72,7 +72,6 @@
   ],
   "start_datetime": "2020-04-02T00:00:00Z",
   "end_datetime": "2021-02-24T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.028110Z",
   "title": "Polar Low detection from S-1 data",
   "extent": {

--- a/projects/polar-snow-on-sea-ice/collection.json
+++ b/projects/polar-snow-on-sea-ice/collection.json
@@ -113,7 +113,6 @@
   ],
   "start_datetime": "2020-07-10T00:00:00Z",
   "end_datetime": "2022-01-11T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.997110Z",
   "title": "Polar+ Snow on Sea ice",
   "extent": {

--- a/projects/pre-melt-preconditioning-the-trigger-for-rapid-arctic-ice-melt/collection.json
+++ b/projects/pre-melt-preconditioning-the-trigger-for-rapid-arctic-ice-melt/collection.json
@@ -72,7 +72,6 @@
   ],
   "start_datetime": "2019-01-12T00:00:00Z",
   "end_datetime": "2022-01-05T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.999110Z",
   "title": "PRE-MELT",
   "extent": {

--- a/projects/pre-operational-sentinel-3-snow-and-ice-products-sice/collection.json
+++ b/projects/pre-operational-sentinel-3-snow-and-ice-products-sice/collection.json
@@ -107,7 +107,6 @@
   ],
   "start_datetime": "2018-07-08T00:00:00Z",
   "end_datetime": "2019-03-12T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.988110Z",
   "title": "S3 snow and ice products",
   "extent": {

--- a/projects/prisma-s5p-demonstration-for-covid-19-studies/collection.json
+++ b/projects/prisma-s5p-demonstration-for-covid-19-studies/collection.json
@@ -102,7 +102,6 @@
   ],
   "start_datetime": "2020-07-24T00:00:00Z",
   "end_datetime": "2021-06-16T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.995110Z",
   "title": "PRISMA+S5p for COVID-19",
   "extent": {

--- a/projects/promcom-ch4-co-distributions-via-s5p-swir-iasi-cris-tir-data/collection.json
+++ b/projects/promcom-ch4-co-distributions-via-s5p-swir-iasi-cris-tir-data/collection.json
@@ -77,7 +77,6 @@
   ],
   "start_datetime": "2018-10-23T00:00:00Z",
   "end_datetime": "2020-10-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.990110Z",
   "title": "PROMCOM",
   "extent": {

--- a/projects/represent/collection.json
+++ b/projects/represent/collection.json
@@ -107,7 +107,6 @@
   ],
   "start_datetime": "2022-11-25T00:00:00Z",
   "end_datetime": "2024-12-20T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.985110Z",
   "title": "RepreSent",
   "extent": {

--- a/projects/ridesat-river-flow-monitoring-and-discharge-estimation-by-integrating-multiple-satellite-data/collection.json
+++ b/projects/ridesat-river-flow-monitoring-and-discharge-estimation-by-integrating-multiple-satellite-data/collection.json
@@ -215,7 +215,6 @@
   ],
   "start_datetime": "2018-11-10T00:00:00Z",
   "end_datetime": "2019-11-15T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.992110Z",
   "title": "RIDESAT",
   "extent": {

--- a/projects/s2-for-land-and-water-change-detection-multi-temporal/collection.json
+++ b/projects/s2-for-land-and-water-change-detection-multi-temporal/collection.json
@@ -95,7 +95,6 @@
   ],
   "start_datetime": "2015-01-12T00:00:00Z",
   "end_datetime": "2018-04-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.022110Z",
   "title": "S2 for Land and Water-Change Detection",
   "extent": {

--- a/projects/s2-for-land-and-water-coastal-and-inland-waters-theme/collection.json
+++ b/projects/s2-for-land-and-water-coastal-and-inland-waters-theme/collection.json
@@ -95,7 +95,6 @@
   ],
   "start_datetime": "2015-02-12T00:00:00Z",
   "end_datetime": "2018-01-03T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.025110Z",
   "title": "Meteolakes",
   "extent": {

--- a/projects/satellite-based-run-off-evaluation-and-mapping-stream/collection.json
+++ b/projects/satellite-based-run-off-evaluation-and-mapping-stream/collection.json
@@ -89,7 +89,6 @@
   ],
   "start_datetime": "2019-02-25T00:00:00Z",
   "end_datetime": "2020-01-04T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.032110Z",
   "title": "STREAM",
   "extent": {

--- a/projects/satellite-oceanographic-datasets-for-acidification-oceansoda/collection.json
+++ b/projects/satellite-oceanographic-datasets-for-acidification-oceansoda/collection.json
@@ -113,7 +113,6 @@
   ],
   "start_datetime": "2018-11-22T00:00:00Z",
   "end_datetime": "2020-12-15T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.001110Z",
   "title": "OceanSODA",
   "extent": {

--- a/projects/seasfire-earth-system-deep-learning-for-seasonal-fire-forecasting-in-europe/collection.json
+++ b/projects/seasfire-earth-system-deep-learning-for-seasonal-fire-forecasting-in-europe/collection.json
@@ -89,7 +89,6 @@
   ],
   "start_datetime": "2021-09-28T00:00:00Z",
   "end_datetime": "2025-01-15T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.011110Z",
   "title": "SeasFire",
   "extent": {

--- a/projects/sen4carbon-theme-1-terrestrial-gross-primary-production-sen4gpp/collection.json
+++ b/projects/sen4carbon-theme-1-terrestrial-gross-primary-production-sen4gpp/collection.json
@@ -113,7 +113,6 @@
   ],
   "start_datetime": "2021-04-22T00:00:00Z",
   "end_datetime": "2023-06-14T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.026110Z",
   "title": "SENSE4GPP",
   "extent": {

--- a/projects/sen4carbon-theme-2-fire-dynamics-sense4fire/collection.json
+++ b/projects/sen4carbon-theme-2-fire-dynamics-sense4fire/collection.json
@@ -89,7 +89,6 @@
   ],
   "start_datetime": "2021-05-27T00:00:00Z",
   "end_datetime": "2023-01-08T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.033110Z",
   "title": "SENSE4FIRE",
   "extent": {

--- a/projects/sentinel-1-for-science-amazonas/collection.json
+++ b/projects/sentinel-1-for-science-amazonas/collection.json
@@ -95,7 +95,6 @@
   ],
   "start_datetime": "2020-04-28T00:00:00Z",
   "end_datetime": "2022-05-05T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.035110Z",
   "title": "S14SCIENCE AMAZONAS",
   "extent": {

--- a/projects/sentinel-1-for-surface-soil-moisture/collection.json
+++ b/projects/sentinel-1-for-surface-soil-moisture/collection.json
@@ -101,7 +101,6 @@
   ],
   "start_datetime": "2016-10-20T00:00:00Z",
   "end_datetime": "2018-01-11T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.018110Z",
   "title": "S1 for Surface Soil Moisture",
   "extent": {

--- a/projects/sentinel-3-for-science-land-study-1-snow/collection.json
+++ b/projects/sentinel-3-for-science-land-study-1-snow/collection.json
@@ -122,7 +122,6 @@
   ],
   "start_datetime": "2016-10-11T00:00:00Z",
   "end_datetime": "2019-03-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.015110Z",
   "title": "S34Science: Snow",
   "extent": {

--- a/projects/sentinel-3-hydrologic-altimetry-processor-prototype-shape/collection.json
+++ b/projects/sentinel-3-hydrologic-altimetry-processor-prototype-shape/collection.json
@@ -101,7 +101,6 @@
   ],
   "start_datetime": "2015-09-22T00:00:00Z",
   "end_datetime": "2019-09-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.026110Z",
   "title": "SHAPE",
   "extent": {

--- a/projects/sentinel-3-performance-improvement-for-ice-sheets-spice/collection.json
+++ b/projects/sentinel-3-performance-improvement-for-ice-sheets-spice/collection.json
@@ -107,7 +107,6 @@
   ],
   "start_datetime": "2015-09-21T00:00:00Z",
   "end_datetime": "2019-09-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.989110Z",
   "title": "SPICE",
   "extent": {

--- a/projects/sentinel-3-primary-production-over-land-terra-p/collection.json
+++ b/projects/sentinel-3-primary-production-over-land-terra-p/collection.json
@@ -95,7 +95,6 @@
   ],
   "start_datetime": "2016-09-26T00:00:00Z",
   "end_datetime": "2022-01-01T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.031110Z",
   "title": "TerrA-P",
   "extent": {

--- a/projects/sentinel-3-tandem-for-climate-s3tc-expro/collection.json
+++ b/projects/sentinel-3-tandem-for-climate-s3tc-expro/collection.json
@@ -113,7 +113,6 @@
   ],
   "start_datetime": "2018-05-28T00:00:00Z",
   "end_datetime": "2020-03-16T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.016110Z",
   "title": "S3 Tandem for Climate",
   "extent": {

--- a/projects/sentinel-5p-innovation-aerosol-optical-depth-aod-and-bidirectional-reflectance-distribution-function-brdf/collection.json
+++ b/projects/sentinel-5p-innovation-aerosol-optical-depth-aod-and-bidirectional-reflectance-distribution-function-brdf/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2019-01-07T00:00:00Z",
   "end_datetime": "2021-12-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.033110Z",
   "title": "S5p Inno - AOD and BRDF",
   "extent": {

--- a/projects/sentinel-5p-innovation-aeurs-water-vapour-isotopologues-h2o-iso/collection.json
+++ b/projects/sentinel-5p-innovation-aeurs-water-vapour-isotopologues-h2o-iso/collection.json
@@ -89,7 +89,6 @@
   ],
   "start_datetime": "2019-02-07T00:00:00Z",
   "end_datetime": "2021-12-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.989110Z",
   "title": "S5p Inno - H2O-ISO",
   "extent": {

--- a/projects/sentinel-5p-innovation-chlorine-dioxide-oclo/collection.json
+++ b/projects/sentinel-5p-innovation-chlorine-dioxide-oclo/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2019-06-25T00:00:00Z",
   "end_datetime": "2021-12-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.011110Z",
   "title": "S5p Inno - OCLO",
   "extent": {

--- a/projects/sentinel-5p-innovation-glyretro-glyoxal-retrievals-from-tropomi/collection.json
+++ b/projects/sentinel-5p-innovation-glyretro-glyoxal-retrievals-from-tropomi/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2019-06-26T00:00:00Z",
   "end_datetime": "2021-12-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.018110Z",
   "title": "S5p Inno - Glyoxal",
   "extent": {

--- a/projects/sentinel-5p-innovation-ocean-colour-s5p-i-oc/collection.json
+++ b/projects/sentinel-5p-innovation-ocean-colour-s5p-i-oc/collection.json
@@ -143,7 +143,6 @@
   ],
   "start_datetime": "2019-05-29T00:00:00Z",
   "end_datetime": "2021-06-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.014110Z",
   "title": "S5p Inno - S5p-I-OC",
   "extent": {

--- a/projects/sentinel-5p-innovation-so2-layer-height-project/collection.json
+++ b/projects/sentinel-5p-innovation-so2-layer-height-project/collection.json
@@ -89,7 +89,6 @@
   ],
   "start_datetime": "2019-03-07T00:00:00Z",
   "end_datetime": "2022-03-20T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.032110Z",
   "title": "S5p Inno - SO2-LH",
   "extent": {

--- a/projects/sentinel-5p-innovation-solar-induced-chlorophyll-fluorescence-sif/collection.json
+++ b/projects/sentinel-5p-innovation-solar-induced-chlorophyll-fluorescence-sif/collection.json
@@ -92,7 +92,6 @@
   ],
   "start_datetime": "2019-03-07T00:00:00Z",
   "end_datetime": "2021-09-11T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.009110Z",
   "title": "S5p Inno - SIF",
   "extent": {

--- a/projects/sentinel-5p-innovation-water-vapour-isotopologues-h2o-iso/collection.json
+++ b/projects/sentinel-5p-innovation-water-vapour-isotopologues-h2o-iso/collection.json
@@ -89,7 +89,6 @@
   ],
   "start_datetime": "2019-02-07T00:00:00Z",
   "end_datetime": "2021-12-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.024110Z",
   "title": "S5p Inno - H2O-ISO",
   "extent": {

--- a/projects/shred-sentinel-1-for-high-resolution-monitoring-of-vegetation-dynamics/collection.json
+++ b/projects/shred-sentinel-1-for-high-resolution-monitoring-of-vegetation-dynamics/collection.json
@@ -77,7 +77,6 @@
   ],
   "start_datetime": "2018-02-10T00:00:00Z",
   "end_datetime": "2020-10-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.019110Z",
   "title": "(LPF) SHRED",
   "extent": {

--- a/projects/smos-med-sea-surface-salinity-in-the-mediterranean/collection.json
+++ b/projects/smos-med-sea-surface-salinity-in-the-mediterranean/collection.json
@@ -89,7 +89,6 @@
   ],
   "start_datetime": "2014-03-19T00:00:00Z",
   "end_datetime": "2018-02-28T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.981110Z",
   "title": "SMOS+ Mediterranean",
   "extent": {

--- a/projects/smos-rainfall-land/collection.json
+++ b/projects/smos-rainfall-land/collection.json
@@ -119,7 +119,6 @@
   ],
   "start_datetime": "2015-07-16T00:00:00Z",
   "end_datetime": "2019-03-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.995110Z",
   "title": "SMOS+ Rainfall Land",
   "extent": {

--- a/projects/smos-vegetation/collection.json
+++ b/projects/smos-vegetation/collection.json
@@ -101,7 +101,6 @@
   ],
   "start_datetime": "2016-10-05T00:00:00Z",
   "end_datetime": "2018-12-15T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.998110Z",
   "title": "SMOS+ VEGETATION",
   "extent": {

--- a/projects/smows-satellite-mode-waters-salinity-in-synergy-with-temperature-and-sea-level/collection.json
+++ b/projects/smows-satellite-mode-waters-salinity-in-synergy-with-temperature-and-sea-level/collection.json
@@ -77,7 +77,6 @@
   ],
   "start_datetime": "2018-09-10T00:00:00Z",
   "end_datetime": "2020-10-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.000110Z",
   "title": "(LPF) SMOWS",
   "extent": {

--- a/projects/so-fresh/collection.json
+++ b/projects/so-fresh/collection.json
@@ -95,7 +95,6 @@
   ],
   "start_datetime": "2021-05-01T00:00:00Z",
   "end_datetime": "2023-05-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.991110Z",
   "title": "Southern Ocean Freshwater (SO-FRESH)",
   "extent": {

--- a/projects/space4safesea/collection.json
+++ b/projects/space4safesea/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2021-02-07T00:00:00Z",
   "end_datetime": "2022-02-07T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.003110Z",
   "title": "Space4SafeSea",
   "extent": {

--- a/projects/stratospheric-ozone-from-limb-observations-validation-of-the-profiles-evaluation-of-trends-and-their-dynamical-and-chemical-drivers-solve/collection.json
+++ b/projects/stratospheric-ozone-from-limb-observations-validation-of-the-profiles-evaluation-of-trends-and-their-dynamical-and-chemical-drivers-solve/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2020-11-09T00:00:00Z",
   "end_datetime": "2023-01-11T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.036110Z",
   "title": "(LPF) SOLVE",
   "extent": {

--- a/projects/stse-arctic-theme-5-aeur-contributions-to-the-year-of-polar-predictions-yopp/collection.json
+++ b/projects/stse-arctic-theme-5-aeur-contributions-to-the-year-of-polar-predictions-yopp/collection.json
@@ -89,7 +89,6 @@
   ],
   "start_datetime": "2016-06-06T00:00:00Z",
   "end_datetime": "2018-02-28T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.983110Z",
   "title": "STSE-ARCTIC+",
   "extent": {

--- a/projects/stse-arctic-theme-5-contributions-to-the-year-of-polar-predictions-yopp/collection.json
+++ b/projects/stse-arctic-theme-5-contributions-to-the-year-of-polar-predictions-yopp/collection.json
@@ -95,7 +95,6 @@
   ],
   "start_datetime": "2016-06-06T00:00:00Z",
   "end_datetime": "2018-02-28T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.982110Z",
   "title": "STSE-ARCTIC+",
   "extent": {

--- a/projects/stse-cryosat-cryotop-evolution/collection.json
+++ b/projects/stse-cryosat-cryotop-evolution/collection.json
@@ -125,7 +125,6 @@
   ],
   "start_datetime": "2016-03-03T00:00:00Z",
   "end_datetime": "2019-11-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.020110Z",
   "title": "CryoSat+ CryoTop Evolution",
   "extent": {

--- a/projects/stse-smos-sea-ice/collection.json
+++ b/projects/stse-smos-sea-ice/collection.json
@@ -107,7 +107,6 @@
   ],
   "start_datetime": "2014-08-20T00:00:00Z",
   "end_datetime": "2017-10-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.026110Z",
   "title": "SMOS+ SeaIce",
   "extent": {

--- a/projects/sunlit-synergy-of-using-nadir-and-limb-instruments-for-tropospheric-ozone-monitoring/collection.json
+++ b/projects/sunlit-synergy-of-using-nadir-and-limb-instruments-for-tropospheric-ozone-monitoring/collection.json
@@ -95,7 +95,6 @@
   ],
   "start_datetime": "2018-05-09T00:00:00Z",
   "end_datetime": "2020-11-24T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.986110Z",
   "title": "SUNLIT",
   "extent": {

--- a/projects/swarm-coupling-high-low-atmosphere-interactions-ion-outflow/collection.json
+++ b/projects/swarm-coupling-high-low-atmosphere-interactions-ion-outflow/collection.json
@@ -101,7 +101,6 @@
   ],
   "start_datetime": "2019-02-22T00:00:00Z",
   "end_datetime": "2020-09-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.027110Z",
   "title": "Swarm+ Outflow",
   "extent": {

--- a/projects/swarm-coupling-high-low-atmosphere-interactions-vertical-coupling-in-earth-s-atmosphere-at-mid-and-high-latitudes-vera/collection.json
+++ b/projects/swarm-coupling-high-low-atmosphere-interactions-vertical-coupling-in-earth-s-atmosphere-at-mid-and-high-latitudes-vera/collection.json
@@ -95,7 +95,6 @@
   ],
   "start_datetime": "2019-02-22T00:00:00Z",
   "end_datetime": "2020-11-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.000110Z",
   "title": "VERA",
   "extent": {

--- a/projects/synergetic-retrieval-from-multi-mission-space-borne-measurements-for-enhancement-of-aerosol-characterization-syremis/collection.json
+++ b/projects/synergetic-retrieval-from-multi-mission-space-borne-measurements-for-enhancement-of-aerosol-characterization-syremis/collection.json
@@ -72,7 +72,6 @@
   ],
   "start_datetime": "2022-11-11T00:00:00Z",
   "end_datetime": "2025-01-02T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.002110Z",
   "title": "SYREMIS",
   "extent": {

--- a/projects/the-4d-earth-swarm-project/collection.json
+++ b/projects/the-4d-earth-swarm-project/collection.json
@@ -182,7 +182,6 @@
   ],
   "start_datetime": "2019-04-16T00:00:00Z",
   "end_datetime": "2022-04-30T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.984110Z",
   "title": "4D-Earth SWARM",
   "extent": {

--- a/projects/towards-the-retrieval-of-lake-ice-thickness-from-satellite-altimetry-missions-liam/collection.json
+++ b/projects/towards-the-retrieval-of-lake-ice-thickness-from-satellite-altimetry-missions-liam/collection.json
@@ -89,7 +89,6 @@
   ],
   "start_datetime": "2020-09-06T00:00:00Z",
   "end_datetime": "2021-08-06T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.017110Z",
   "title": "LIAM",
   "extent": {

--- a/projects/understand-and-mitigate-impacts-of-3d-clouds-on-uv-vis-no2-trace-gas-retrievals-by-ai-exploration-of-synthetic-and-real-data-mit3d/collection.json
+++ b/projects/understand-and-mitigate-impacts-of-3d-clouds-on-uv-vis-no2-trace-gas-retrievals-by-ai-exploration-of-synthetic-and-real-data-mit3d/collection.json
@@ -78,7 +78,6 @@
   ],
   "start_datetime": "2022-03-16T00:00:00Z",
   "end_datetime": "2025-01-04T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.033110Z",
   "title": "MIT3D",
   "extent": {

--- a/projects/using-deep-learning-with-cryosat-radar-altimetry-to-adjust-elevations-and-map-surface-penetration-cryosurf/collection.json
+++ b/projects/using-deep-learning-with-cryosat-radar-altimetry-to-adjust-elevations-and-map-surface-penetration-cryosurf/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2019-10-22T00:00:00Z",
   "end_datetime": "2020-12-11T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.003110Z",
   "title": "CryoSURF",
   "extent": {

--- a/projects/vad3emecum-vegetation-and-drought-towards-improved-data-driven-estimated-of-ecosystem-carbon-fluxes-under-moisture-stress/collection.json
+++ b/projects/vad3emecum-vegetation-and-drought-towards-improved-data-driven-estimated-of-ecosystem-carbon-fluxes-under-moisture-stress/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2020-04-29T00:00:00Z",
   "end_datetime": "2022-01-06T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.025110Z",
   "title": "(LPF) VAD3EMECUM",
   "extent": {

--- a/projects/volcanic-monitoring-using-sentinel-sensors-by-an-integrated-approach-vista/collection.json
+++ b/projects/volcanic-monitoring-using-sentinel-sensors-by-an-integrated-approach-vista/collection.json
@@ -107,7 +107,6 @@
   ],
   "start_datetime": "2019-03-09T00:00:00Z",
   "end_datetime": "2021-11-16T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.007110Z",
   "title": "VISTA",
   "extent": {

--- a/projects/volcano-monitoring-using-deep-learning/collection.json
+++ b/projects/volcano-monitoring-using-deep-learning/collection.json
@@ -98,7 +98,6 @@
   ],
   "start_datetime": "2020-06-23T00:00:00Z",
   "end_datetime": "2022-01-07T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.008110Z",
   "title": "(LPF) VMDL",
   "extent": {

--- a/projects/wacmos-irrigation/collection.json
+++ b/projects/wacmos-irrigation/collection.json
@@ -77,7 +77,6 @@
   ],
   "start_datetime": "2017-01-24T00:00:00Z",
   "end_datetime": "2018-01-02T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:22.991110Z",
   "title": "WACMOS Irrigation",
   "extent": {

--- a/projects/water-cycle-changes-characterised-from-atmospheric-moisture-recycling-weather/collection.json
+++ b/projects/water-cycle-changes-characterised-from-atmospheric-moisture-recycling-weather/collection.json
@@ -83,7 +83,6 @@
   ],
   "start_datetime": "2020-04-29T00:00:00Z",
   "end_datetime": "2022-01-06T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.021110Z",
   "title": "(LPF) WEATHER",
   "extent": {

--- a/projects/water-vapour-isotopologue-flask-sampling-for-the-validation-of-satellite-data-wifvos/collection.json
+++ b/projects/water-vapour-isotopologue-flask-sampling-for-the-validation-of-satellite-data-wifvos/collection.json
@@ -89,7 +89,6 @@
   ],
   "start_datetime": "2021-03-03T00:00:00Z",
   "end_datetime": "2022-03-03T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.027110Z",
   "title": "WIFOS",
   "extent": {

--- a/projects/wift-water-vapour-isotopologues-from-tropomi/collection.json
+++ b/projects/wift-water-vapour-isotopologues-from-tropomi/collection.json
@@ -101,7 +101,6 @@
   ],
   "start_datetime": "2018-10-17T00:00:00Z",
   "end_datetime": "2020-10-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.023110Z",
   "title": "(LPF) WIFT",
   "extent": {

--- a/projects/world-ocean-circulation/collection.json
+++ b/projects/world-ocean-circulation/collection.json
@@ -197,7 +197,6 @@
   ],
   "start_datetime": "2020-04-28T00:00:00Z",
   "end_datetime": "2022-05-31T23:59:59Z",
-  "osc:missions": [],
   "updated": "2024-09-12T20:32:23.010110Z",
   "title": "WOC",
   "extent": {


### PR DESCRIPTION
Our understanding of the ESA request.

The only osc:missions which was not empty was projects/lpf-wise/collection.json. None of them had a link.