### PR TITLE
worldcereal: updated records for consistent naming

### DIFF
--- a/experiments/worldcereal-experiment/record.json
+++ b/experiments/worldcereal-experiment/record.json
@@ -10,7 +10,7 @@
     "updated": "2025-01-21T18:40:00Z",
     "type": "experiment",
     "title": "ESA WorldCereal Experiment",
-    "description": "A maize detection algorithm experiment",
+    "description": "Experiment using the worldcereal crop extent workflow.",
     "keywords": [
       "agriculture",
       "crops"
@@ -98,7 +98,7 @@
     },
     {
       "rel": "child",
-      "href": "../../products/worldcereal-maize-detection-belgium/collection.json",
+      "href": "../../products/worldcereal-crop-extent-belgium/collection.json",
       "type": "application/json",
       "title": "WorldCereal Crop Extent - Belgium"
     },
@@ -113,12 +113,6 @@
       "href": "./environment.yaml",
       "type": "application/yaml",
       "title": "Execution environment"
-    },
-    {
-      "rel": "openeo-process-graph",
-      "type": "application/json",
-      "title": "openEO Processing Graph",
-      "href": "https://openeofed.dataspace.copernicus.eu/openeo/1.2/jobs/cdse-j-25020410530548a7aef81c62faebd127"
     },
     {
       "rel": "service",
@@ -136,7 +130,7 @@
       "rel": "related",
       "href": "../../workflows/worldcereal-workflow/record.json",
       "type": "application/json",
-      "title": "Workflow: ESA worldcereal global maize detector"
+      "title": "Workflow: ESA worldcereal global crop extent detector"
     },
     {
       "rel": "self",

--- a/products/catalog.json
+++ b/products/catalog.json
@@ -1794,7 +1794,7 @@
     },
     {
       "rel": "child",
-      "href": "./worldcereal-maize-detection-belgium/collection.json",
+      "href": "./worldcereal-crop-extent-belgium/collection.json",
       "type": "application/json",
       "title": "WorldCereal Crop Extent - Belgium"
     },

--- a/products/worldcereal-crop-extent-belgium/collection.json
+++ b/products/worldcereal-crop-extent-belgium/collection.json
@@ -1,6 +1,6 @@
 {
   "type": "Collection",
-  "id": "worldcereal-maize-detection-belgium",
+  "id": "worldcereal-crop-extent-belgium",
   "stac_version": "1.0.0",
   "description": "Results for batch job cdse-j-25020410530548a7aef81c62faebd127",
   "title": "WorldCereal Crop Extent - Belgium",

--- a/projects/worldcereal/collection.json
+++ b/projects/worldcereal/collection.json
@@ -21,12 +21,6 @@
       "title": "EO4Society Link"
     },
     {
-      "rel": "child",
-      "href": "../../products/worldcereal-maize-detection-belgium/collection.json",
-      "type": "application/json",
-      "title": "WorldCereal Crop Extent - Belgium"
-    },
-    {
       "rel": "parent",
       "href": "../catalog.json",
       "type": "application/json",
@@ -47,11 +41,11 @@
       "rel": "related",
       "href": "../../workflows/worldcereal-workflow/record.json",
       "type": "application/json",
-      "title": "Workflow: ESA worldcereal global maize detector"
+      "title": "Workflow: ESA worldcereal global crop extent detector"
     },
     {
       "rel": "related",
-      "href": "../../products/worldcereal-maize-detection-belgium/collection.json",
+      "href": "../../products/worldcereal-crop-extent-belgium/collection.json",
       "type": "application/json",
       "title": "Product: WorldCereal Crop Extent - Belgium"
     }

--- a/workflows/catalog.json
+++ b/workflows/catalog.json
@@ -20,7 +20,7 @@
       "rel": "item",
       "href": "./worldcereal-workflow/record.json",
       "type": "application/json",
-      "title": "ESA worldcereal global maize detector"
+      "title": "ESA worldcereal global crop extent detector"
     },
     {
       "rel": "parent",

--- a/workflows/worldcereal-workflow/record.json
+++ b/workflows/worldcereal-workflow/record.json
@@ -9,8 +9,8 @@
     "created": "2025-01-21T18:00:00Z",
     "updated": "2025-01-21T18:40:00Z",
     "type": "workflow",
-    "title": "ESA worldcereal global maize detector",
-    "description": "A maize detection algorithm.",
+    "title": "ESA worldcereal global crop extent detector",
+    "description": "Detects crop land at 10m resolution, trained for global use. Based on Sentinel-1 and 2 data, this algorithm can be used from 2016 onwards. The maximum area for a single job is 20x20km.",
     "keywords": [
       "agriculture",
       "crops"
@@ -38,10 +38,11 @@
         ]
       },
       {
-        "name": "VITO",
+        "name": "Copernicus Dataspace Ecosystem",
         "links": [
           {
-            "href": "https://www.vito.be/",
+            "href": "https://dataspace.copernicus.eu/",
+            "title": "CDSE Platform Website",
             "rel": "about",
             "type": "text/html"
           }
@@ -118,7 +119,7 @@
       "rel": "openeo-process",
       "type": "application/json",
       "title": "openEO Process Definition",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/refs/heads/main/openeo_udp/worldcereal_crop_extent.json"
+      "href": "https://raw.githubusercontent.com/WorldCereal/worldcereal-classification/refs/tags/worldcereal_crop_extent_v1.0.1/src/worldcereal/udp/worldcereal_crop_extent.json"
     },
     {
       "rel": "git",
@@ -131,10 +132,6 @@
       "type": "application/json",
       "title": "CDSE openEO federation",
       "href": "https://openeofed.dataspace.copernicus.eu"
-    },
-    {
-      "rel": "license",
-      "href": "https://apex.esa.int/license"
     },
     {
       "rel": "self",


### PR DESCRIPTION
The initial WorldCereal example contained some manually filled fields, as it was primarily used as an example for validation. However, there were inconsistencies in the titles and descriptions. This PR corrects those inconsistencies.