### PR TITLE
fix access link

### DIFF
--- a/products/baltic-sea-level-baltic-seal/collection.json
+++ b/products/baltic-sea-level-baltic-seal/collection.json
@@ -12,7 +12,7 @@
     },
     {
       "rel": "via",
-      "href": "",
+      "href": "https://www.dgfi.tum.de/en/projects/baltic-sea-level/",
       "title": "Access"
     },
     {


### PR DESCRIPTION
Stumbled upon this during https://github.com/ESA-EarthCODE/bids2025-tutorial

How do we provide the correct link?