### PR TITLE
Adding EOWetMet project and product entries

### DIFF
--- a/products/catalog.json
+++ b/products/catalog.json
@@ -2078,7 +2078,49 @@
       "href": "./ai4ais-larsen-c-ice-shelf-cube/collection.json",
       "type": "application/json",
       "title": "AI4AIS Larsen C ice shelf cube"
-    }
+    },
+    {
+      "rel": "child",
+      "href": "./eowetmet-pan-arctic-daily-9km-wetland-methane-flux/collection.json",
+      "type": "application/json",
+      "title": "EOWetMet: Pan-Arctic Daily 9 km Wetland Methane Flux Dataset (2015-2024)"
+    },
+    {
+      "rel": "child",
+      "href": "./eowetmet-pan-arctic-monthly-500m-wetland-methane-flux/collection.json",
+      "type": "application/json",
+      "title": "EOWetMet: Pan-Arctic Monthly 500 m Wetland Methane Flux Dataset (2015-2024)"
+    },
+    {
+      "rel": "child",
+      "href": "./eowetmet-pan-arctic-average-wetland-methane-flux/collection.json",
+      "type": "application/json",
+      "title": "EOWetMet: Pan-Arctic Average Wetland Methane Flux Dataset (2015-2024)"
+    },
+    {
+      "rel": "child",
+      "href": "./eowetmet-regional-30m-wetland-methane-flux/collection.json",
+      "type": "application/json",
+      "title": "EOWetMet: Regional High-Resolution 30 m Wetland Methane Flux Dataset (2025)"
+    },
+    {
+      "rel": "child",
+      "href": "./eowetmet-annual-wetland-lake-classification-nwt-sweden/collection.json",
+      "type": "application/json",
+      "title": "EOWetMet: Annual Wetland and Lake Classification Dataset for NWT and Sweden (2021-2025)"
+    },
+    {
+      "rel": "child",
+      "href": "./eowetmet-seasonal-inundation-nwt-sweden/collection.json",
+      "type": "application/json",
+      "title": "EOWetMet: Seasonal Inundation Dataset for NWT and Sweden (2021-2025)"
+    },
+    {
+      "rel": "child",
+      "href": "./eowetmet-annual-lake-ice-regime-classification-nwt-sweden/collection.json",
+      "type": "application/json",
+      "title": "EOWetMet: Annual Lake Ice Regime Classification Dataset for NWT and Sweden (2021-2025)"
+    }    
   ],
   "updated": "2024-09-12T20:32:22.975110Z",
   "title": "Products"

--- a/products/eowetmet-annual-lake-ice-regime-classification-nwt-sweden/collection.json
+++ b/products/eowetmet-annual-lake-ice-regime-classification-nwt-sweden/collection.json
@@ -1,0 +1,42 @@
+{
+  "type": "Collection",
+  "id": "eowetmet-annual-lake-ice-regime-classification-nwt-sweden",
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/osc/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/themes/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/cf/v0.2.0/schema.json"
+  ],
+  "created": "2026-06-17T00:00:00Z",
+  "updated": "2026-06-18T00:00:00Z",
+  "title": "EOWetMet: Annual Lake Ice Regime Classification Dataset for NWT and Sweden (2021-2025)",
+  "description": "The EOWetMet Annual Lake Ice Regime Classification Dataset (2021-2025) provides annual peak-winter classifications of lake ice regime across two Arctic 500 km x 500 km study areas in the Northwest Territories, Canada, and northern Sweden for the period 2021 to 2025. The dataset distinguishes floating ice and bedfast ice regimes within lakes at the pixel level. The dataset forms part of the EOWetMet Community Database and was developed to provide a high-resolution, annually dynamic lake ice regime product supporting bottom-up lake methane emission modelling, permafrost and thermokarst monitoring, freshwater ecology and overwinter habitat assessment, and northern infrastructure and winter water supply planning. Lake ice regime classifications were derived from Sentinel-1 C-band SAR imagery acquired near the timing of maximum ice thickness in late winter, prior to the onset of spring surface melt. Products are delivered at 10 m spatial resolution.",
+  "extent": {
+    "spatial": {
+      "bbox": [[-180.0, 45.0, 180.0, 90.0]]
+    },
+    "temporal": {
+      "interval": [["2021-01-01T00:00:00Z", "2025-12-31T23:59:59Z"]]
+    }
+  },
+  "keywords": ["lake ice", "bedfast ice", "floating ice", "Arctic", "Northwest Territories", "Sweden", "Earth Observation", "remote sensing", "Sentinel-1", "permafrost"],
+  "osc:project": "eowetmet",
+  "osc:region": "Northwest Territories, Canada; Northern Sweden",
+  "osc:status": "completed",
+  "osc:type": "product",
+  "links": [
+    {"href": "../../catalog.json", "rel": "root", "title": "Open Science Catalog", "type": "application/json"},
+    {"href": "../catalog.json", "rel": "parent", "title": "Products", "type": "application/json"},
+    {"href": "../../projects/eowetmet/collection.json", "rel": "related", "title": "Project: EOWetMet", "type": "application/json"},
+    {"href": "../../themes/land/catalog.json", "rel": "related", "title": "Theme: Land", "type": "application/json"},
+    {"href": "../../eo-missions/sentinel-1/catalog.json", "rel": "related", "title": "EO Mission: Sentinel-1", "type": "application/json"},
+    {"href": "../../variables/methane/catalog.json", "rel": "related", "title": "Variable: Methane", "type": "application/json"},
+    {"href": "https://doi.org/10.5281/zenodo.20708748", "rel": "via", "title": "Access"}
+  ],
+  "osc:missions": ["sentinel-1"],
+  "osc:variables": ["methane"],
+  "cf:parameter": [{"name": "methane"}],
+  "sci:doi": "10.5281/zenodo.20708748",
+  "themes": [{"concepts": [{"id": "land"}], "scheme": "https://github.com/stac-extensions/osc#theme"}],
+  "license": "CC-BY-4.0"
+}

--- a/products/eowetmet-annual-wetland-lake-classification-nwt-sweden/collection.json
+++ b/products/eowetmet-annual-wetland-lake-classification-nwt-sweden/collection.json
@@ -1,0 +1,43 @@
+{
+  "type": "Collection",
+  "id": "eowetmet-annual-wetland-lake-classification-nwt-sweden",
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/osc/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/themes/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/cf/v0.2.0/schema.json"
+  ],
+  "created": "2026-06-17T00:00:00Z",
+  "updated": "2026-06-17T00:00:00Z",
+  "title": "EOWetMet: Annual Wetland and Lake Classification Dataset for NWT and Sweden (2021-2025)",
+  "description": "The EOWetMet Annual Wetland and Lake Classification Dataset (2021-2025) provides annual land cover maps distinguishing six wetland and lake ecosystem classes across two Arctic 500 km x 500 km study areas in the Northwest Territories (NWT), Canada, and northern Sweden, for the period 2021 to 2025. The dataset forms part of the EOWetMet Community Product Database and was developed to capture the spatial and temporal characterisation of wetland and lake inundation at high resolution, in support of bottom-up methane emission modelling and a broad range of Arctic science applications, including hydrological monitoring, permafrost and thermokarst change detection, and biodiversity assessment. The classification was produced using an Object-Based Image Analysis Random Forest framework implemented in Google Earth Engine, integrating 35 input features from multiple data categories, including Sentinel-1, Sentinel-2, ALOS PALSAR-2, ArcticDEM, ERA5, MERIT Hydro, and annual inundation information derived from Sentinel-1. Products are delivered at 10 m spatial resolution.",
+  "extent": {
+    "spatial": {
+      "bbox": [[-180.0, 45.0, 180.0, 90.0]]
+    },
+    "temporal": {
+      "interval": [["2021-01-01T00:00:00Z", "2025-12-31T23:59:59Z"]]
+    }
+  },
+  "keywords": ["wetlands", "Arctic", "land cover", "wetland classification", "Northwest Territories", "Sweden", "Earth Observation", "remote sensing", "Sentinel-1", "Sentinel-2"],
+  "osc:project": "eowetmet",
+  "osc:region": "Northwest Territories, Canada; Northern Sweden",
+  "osc:status": "completed",
+  "osc:type": "product",
+  "links": [
+    {"href": "../../catalog.json", "rel": "root", "title": "Open Science Catalog", "type": "application/json"},
+    {"href": "../catalog.json", "rel": "parent", "title": "Products", "type": "application/json"},
+    {"href": "../../projects/eowetmet/collection.json", "rel": "related", "title": "Project: EOWetMet", "type": "application/json"},
+    {"href": "../../themes/land/catalog.json", "rel": "related", "title": "Theme: Land", "type": "application/json"},
+    {"href": "../../eo-missions/sentinel-1/catalog.json", "rel": "related", "title": "EO Mission: Sentinel-1", "type": "application/json"},
+    {"href": "../../eo-missions/sentinel-2/catalog.json", "rel": "related", "title": "EO Mission: Sentinel-2", "type": "application/json"},
+    {"href": "../../variables/methane/catalog.json", "rel": "related", "title": "Variable: Methane", "type": "application/json"},
+    {"href": "https://doi.org/10.5281/zenodo.20707376", "rel": "via", "title": "Access"}
+  ],
+  "osc:missions": ["sentinel-1", "sentinel-2"],
+  "osc:variables": ["methane"],
+  "cf:parameter": [{"name": "methane"}],
+  "sci:doi": "10.5281/zenodo.20707376",
+  "themes": [{"concepts": [{"id": "land"}], "scheme": "https://github.com/stac-extensions/osc#theme"}],
+  "license": "CC-BY-4.0"
+}

--- a/products/eowetmet-pan-arctic-average-wetland-methane-flux/collection.json
+++ b/products/eowetmet-pan-arctic-average-wetland-methane-flux/collection.json
@@ -1,0 +1,41 @@
+{
+  "type": "Collection",
+  "id": "eowetmet-pan-arctic-average-wetland-methane-flux",
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/osc/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/themes/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/cf/v0.2.0/schema.json"
+  ],
+  "created": "2026-06-05T00:00:00Z",
+  "updated": "2026-06-16T00:00:00Z",
+  "title": "EOWetMet: Pan-Arctic Average Wetland Methane Flux Dataset (2015-2024)",
+  "description": "The EOWetMet Pan-Arctic Average Wetland Methane Flux Dataset provides period-average methane flux maps for northern and Arctic wetlands derived from the EOWetMet Database. The dataset includes average methane flux products derived from the EOWetMet Random Forest methane upscaling framework using four wetland and land-cover map configurations: PAWM, BAWLD, WAD2M, and MODIS IGBP. The repository also includes benchmark average methane products derived from CarbonTracker and the WetCHARTs ensemble to facilitate comparison between EOWetMet methane flux estimates and widely used top-down and bottom-up methane emission datasets.",
+  "extent": {
+    "spatial": {
+      "bbox": [[-180.0, 45.0, 180.0, 90.0]]
+    },
+    "temporal": {
+      "interval": [["2015-01-01T00:00:00Z", "2024-12-31T23:59:59Z"]]
+    }
+  },
+  "keywords": ["wetlands", "Arctic", "methane", "methane flux", "Pan-Arctic", "Earth Observation", "greenhouse gases", "remote sensing"],
+  "osc:project": "eowetmet",
+  "osc:region": "Pan-Arctic",
+  "osc:status": "completed",
+  "osc:type": "product",
+  "links": [
+    {"href": "../../catalog.json", "rel": "root", "title": "Open Science Catalog", "type": "application/json"},
+    {"href": "../catalog.json", "rel": "parent", "title": "Products", "type": "application/json"},
+    {"href": "../../projects/eowetmet/collection.json", "rel": "related", "title": "Project: EOWetMet", "type": "application/json"},
+    {"href": "../../themes/land/catalog.json", "rel": "related", "title": "Theme: Land", "type": "application/json"},
+    {"href": "../../variables/methane/catalog.json", "rel": "related", "title": "Variable: Methane", "type": "application/json"},
+    {"href": "https://doi.org/10.5281/zenodo.20547980", "rel": "via", "title": "Access"}
+  ],
+  "osc:missions": [],
+  "osc:variables": ["methane"],
+  "cf:parameter": [{"name": "methane"}],
+  "sci:doi": "10.5281/zenodo.20547980",
+  "themes": [{"concepts": [{"id": "land"}], "scheme": "https://github.com/stac-extensions/osc#theme"}],
+  "license": "CC-BY-4.0"
+}

--- a/products/eowetmet-pan-arctic-daily-9km-wetland-methane-flux/collection.json
+++ b/products/eowetmet-pan-arctic-daily-9km-wetland-methane-flux/collection.json
@@ -1,0 +1,42 @@
+{
+  "type": "Collection",
+  "id": "eowetmet-pan-arctic-daily-9km-wetland-methane-flux",
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/osc/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/themes/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/cf/v0.2.0/schema.json"
+  ],
+  "created": "2026-06-05T00:00:00Z",
+  "updated": "2026-06-18T00:00:00Z",
+  "title": "EOWetMet: Pan-Arctic Daily 9 km Wetland Methane Flux Dataset (2015-2024)",
+  "description": "The EOWetMet Pan-Arctic Daily 9 km Wetland Methane Flux Dataset provides daily methane flux estimates across northern and Arctic wetlands from 2015 to 2024. The dataset forms part of the EOWetMet Community Database and was developed through the integration of eddy covariance (EC) methane flux observations, Earth Observation datasets, and environmental reanalysis products within a machine-learning-based methane upscaling framework.",
+  "extent": {
+    "spatial": {
+      "bbox": [[-180.0, 45.0, 180.0, 90.0]]
+    },
+    "temporal": {
+      "interval": [["2015-01-01T00:00:00Z", "2024-12-31T23:59:59Z"]]
+    }
+  },
+  "keywords": ["wetlands", "Arctic", "methane", "methane flux", "Pan-Arctic", "Earth Observation", "greenhouse gases", "remote sensing"],
+  "osc:project": "eowetmet",
+  "osc:region": "Pan-Arctic",
+  "osc:status": "completed",
+  "osc:type": "product",
+  "links": [
+    {"href": "../../catalog.json", "rel": "root", "title": "Open Science Catalog", "type": "application/json"},
+    {"href": "../catalog.json", "rel": "parent", "title": "Products", "type": "application/json"},
+    {"href": "../../projects/eowetmet/collection.json", "rel": "related", "title": "Project: EOWetMet", "type": "application/json"},
+    {"href": "../../themes/land/catalog.json", "rel": "related", "title": "Theme: Land", "type": "application/json"},
+    {"href": "../../eo-missions/sentinel-2/catalog.json", "rel": "related", "title": "EO Mission: Sentinel-2", "type": "application/json"},
+    {"href": "../../variables/methane/catalog.json", "rel": "related", "title": "Variable: Methane", "type": "application/json"},
+    {"href": "https://doi.org/10.5281/zenodo.20545657", "rel": "via", "title": "Access"}
+  ],
+  "osc:missions": ["sentinel-2"],
+  "osc:variables": ["methane"],
+  "cf:parameter": [{"name": "methane"}],
+  "sci:doi": "10.5281/zenodo.20545657",
+  "themes": [{"concepts": [{"id": "land"}], "scheme": "https://github.com/stac-extensions/osc#theme"}],
+  "license": "CC-BY-4.0"
+}

--- a/products/eowetmet-pan-arctic-daily-9km-wetland-methane-flux/collection.json
+++ b/products/eowetmet-pan-arctic-daily-9km-wetland-methane-flux/collection.json
@@ -8,7 +8,7 @@
     "https://stac-extensions.github.io/cf/v0.2.0/schema.json"
   ],
   "created": "2026-06-05T00:00:00Z",
-  "updated": "2026-06-18T00:00:00Z",
+  "updated": "2026-06-16T00:00:00Z",
   "title": "EOWetMet: Pan-Arctic Daily 9 km Wetland Methane Flux Dataset (2015-2024)",
   "description": "The EOWetMet Pan-Arctic Daily 9 km Wetland Methane Flux Dataset provides daily methane flux estimates across northern and Arctic wetlands from 2015 to 2024. The dataset forms part of the EOWetMet Community Database and was developed through the integration of eddy covariance (EC) methane flux observations, Earth Observation datasets, and environmental reanalysis products within a machine-learning-based methane upscaling framework.",
   "extent": {
@@ -29,11 +29,10 @@
     {"href": "../catalog.json", "rel": "parent", "title": "Products", "type": "application/json"},
     {"href": "../../projects/eowetmet/collection.json", "rel": "related", "title": "Project: EOWetMet", "type": "application/json"},
     {"href": "../../themes/land/catalog.json", "rel": "related", "title": "Theme: Land", "type": "application/json"},
-    {"href": "../../eo-missions/sentinel-2/catalog.json", "rel": "related", "title": "EO Mission: Sentinel-2", "type": "application/json"},
     {"href": "../../variables/methane/catalog.json", "rel": "related", "title": "Variable: Methane", "type": "application/json"},
     {"href": "https://doi.org/10.5281/zenodo.20545657", "rel": "via", "title": "Access"}
   ],
-  "osc:missions": ["sentinel-2"],
+  "osc:missions": [],
   "osc:variables": ["methane"],
   "cf:parameter": [{"name": "methane"}],
   "sci:doi": "10.5281/zenodo.20545657",

--- a/products/eowetmet-pan-arctic-monthly-500m-wetland-methane-flux/collection.json
+++ b/products/eowetmet-pan-arctic-monthly-500m-wetland-methane-flux/collection.json
@@ -1,0 +1,41 @@
+{
+  "type": "Collection",
+  "id": "eowetmet-pan-arctic-monthly-500m-wetland-methane-flux",
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/osc/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/themes/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/cf/v0.2.0/schema.json"
+  ],
+  "created": "2026-06-05T00:00:00Z",
+  "updated": "2026-06-17T00:00:00Z",
+  "title": "EOWetMet: Pan-Arctic Monthly 500 m Wetland Methane Flux Dataset (2015-2024)",
+  "description": "The EOWetMet Pan-Arctic Monthly 500 m Wetland Methane Flux Dataset provides monthly methane flux estimates across northern and Arctic wetlands from 2015 to 2024. The dataset forms part of the EOWetMet Community Database and was developed through the integration of eddy covariance methane flux observations, Earth Observation datasets, and environmental reanalysis products within a machine-learning-based methane upscaling framework. Methane flux estimates were generated using a Random Forest regression model trained on Arctic and boreal wetland EC methane flux measurements and driven by environmental predictors derived from ERA5-Land, SMAP, and MODIS products.",
+  "extent": {
+    "spatial": {
+      "bbox": [[-180.0, 45.0, 180.0, 90.0]]
+    },
+    "temporal": {
+      "interval": [["2015-01-01T00:00:00Z", "2024-12-31T23:59:59Z"]]
+    }
+  },
+  "keywords": ["wetlands", "Arctic", "methane", "methane flux", "Pan-Arctic", "Earth Observation", "greenhouse gases", "remote sensing"],
+  "osc:project": "eowetmet",
+  "osc:region": "Pan-Arctic",
+  "osc:status": "completed",
+  "osc:type": "product",
+  "links": [
+    {"href": "../../catalog.json", "rel": "root", "title": "Open Science Catalog", "type": "application/json"},
+    {"href": "../catalog.json", "rel": "parent", "title": "Products", "type": "application/json"},
+    {"href": "../../projects/eowetmet/collection.json", "rel": "related", "title": "Project: EOWetMet", "type": "application/json"},
+    {"href": "../../themes/land/catalog.json", "rel": "related", "title": "Theme: Land", "type": "application/json"},
+    {"href": "../../variables/methane/catalog.json", "rel": "related", "title": "Variable: Methane", "type": "application/json"},
+    {"href": "https://doi.org/10.5281/zenodo.20545323", "rel": "via", "title": "Access"}
+  ],
+  "osc:missions": [],
+  "osc:variables": ["methane"],
+  "cf:parameter": [{"name": "methane"}],
+  "sci:doi": "10.5281/zenodo.20545323",
+  "themes": [{"concepts": [{"id": "land"}], "scheme": "https://github.com/stac-extensions/osc#theme"}],
+  "license": "CC-BY-4.0"
+}

--- a/products/eowetmet-regional-30m-wetland-methane-flux/collection.json
+++ b/products/eowetmet-regional-30m-wetland-methane-flux/collection.json
@@ -1,0 +1,42 @@
+{
+  "type": "Collection",
+  "id": "eowetmet-regional-30m-wetland-methane-flux",
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/osc/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/themes/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/cf/v0.2.0/schema.json"
+  ],
+  "created": "2026-06-05T00:00:00Z",
+  "updated": "2026-06-16T00:00:00Z",
+  "title": "EOWetMet: Regional High-Resolution 30 m Wetland Methane Flux Dataset (2025)",
+  "description": "The EOWetMet Regional High-Resolution 30 m Wetland Methane Flux Dataset provides summer-average methane flux maps for two Arctic case-study regions in 2025. The products were generated using a Geo Foundation Model (GFM)-based deep learning framework that extracts spatial and spectral representations from Harmonized Landsat-Sentinel (HLS) imagery and integrates complementary environmental variables through an attention-based parallel auxiliary module. The repository includes two 30 m GeoTIFF methane flux products representing summer-average conditions over approximately 500 km x 500 km case-study regions in Northwest Territories, Canada, and northern Sweden.",
+  "extent": {
+    "spatial": {
+      "bbox": [[-180.0, 45.0, 180.0, 90.0]]
+    },
+    "temporal": {
+      "interval": [["2025-01-01T00:00:00Z", "2025-12-31T23:59:59Z"]]
+    }
+  },
+  "keywords": ["wetlands", "Arctic", "methane", "methane flux", "Earth Observation", "remote sensing", "HLS", "Harmonized Landsat Sentinel", "Geo Foundation Model", "deep learning"],
+  "osc:project": "eowetmet",
+  "osc:region": "Northwest Territories, Canada; Northern Sweden",
+  "osc:status": "completed",
+  "osc:type": "product",
+  "links": [
+    {"href": "../../catalog.json", "rel": "root", "title": "Open Science Catalog", "type": "application/json"},
+    {"href": "../catalog.json", "rel": "parent", "title": "Products", "type": "application/json"},
+    {"href": "../../projects/eowetmet/collection.json", "rel": "related", "title": "Project: EOWetMet", "type": "application/json"},
+    {"href": "../../themes/land/catalog.json", "rel": "related", "title": "Theme: Land", "type": "application/json"},
+    {"href": "../../eo-missions/sentinel-2/catalog.json", "rel": "related", "title": "EO Mission: Sentinel-2", "type": "application/json"},
+    {"href": "../../variables/methane/catalog.json", "rel": "related", "title": "Variable: Methane", "type": "application/json"},
+    {"href": "https://doi.org/10.5281/zenodo.20548779", "rel": "via", "title": "Access"}
+  ],
+  "osc:missions": ["sentinel-2"],
+  "osc:variables": ["methane"],
+  "cf:parameter": [{"name": "methane"}],
+  "sci:doi": "10.5281/zenodo.20548779",
+  "themes": [{"concepts": [{"id": "land"}], "scheme": "https://github.com/stac-extensions/osc#theme"}],
+  "license": "CC-BY-4.0"
+}

--- a/products/eowetmet-seasonal-inundation-nwt-sweden/collection.json
+++ b/products/eowetmet-seasonal-inundation-nwt-sweden/collection.json
@@ -1,6 +1,6 @@
 {
   "type": "Collection",
-  "id": "eowetmet-annual-wetland-lake-classification-nwt-sweden",
+  "id": "eowetmet-seasonal-inundation-nwt-sweden",
   "stac_version": "1.0.0",
   "stac_extensions": [
     "https://stac-extensions.github.io/osc/v1.0.0/schema.json",
@@ -8,9 +8,9 @@
     "https://stac-extensions.github.io/cf/v0.2.0/schema.json"
   ],
   "created": "2026-06-17T00:00:00Z",
-  "updated": "2026-06-18T00:00:00Z",
-  "title": "EOWetMet: Annual Wetland and Lake Classification Dataset for NWT and Sweden (2021-2025)",
-  "description": "The EOWetMet Annual Wetland and Lake Classification Dataset (2021-2025) provides annual land cover maps distinguishing six wetland and lake ecosystem classes across two Arctic 500 km x 500 km study areas in the Northwest Territories (NWT), Canada, and northern Sweden, for the period 2021 to 2025. The dataset forms part of the EOWetMet Community Product Database and was developed to capture the spatial and temporal characterisation of wetland and lake inundation at high resolution, in support of bottom-up methane emission modelling and a broad range of Arctic science applications, including hydrological monitoring, permafrost and thermokarst change detection, and biodiversity assessment. The classification was produced using an Object-Based Image Analysis Random Forest framework implemented in Google Earth Engine, integrating 35 input features from multiple data categories, including Sentinel-1, Sentinel-2, ALOS PALSAR-2, ArcticDEM, ERA5, MERIT Hydro, and annual inundation information derived from Sentinel-1. Products are delivered at 10 m spatial resolution.",
+  "updated": "2026-06-17T00:00:00Z",
+  "title": "EOWetMet: Seasonal Inundation Dataset for NWT and Sweden (2021-2025)",
+  "description": "The EOWetMet Seasonal Inundation Dataset (2021-2025) provides a seasonal record of surface water and inundation across two 500 km x 500 km Arctic study areas in the Northwest Territories, Canada, and northern Sweden, for the period 2021 to 2025. The dataset forms part of the EOWetMet Community Product Database and was developed to improve the spatial and temporal characterisation of wetlands and lakes at high resolution, in support of bottom-up methane emission modelling and a broad range of Arctic science applications. Inundation estimates were derived using a two-step classification framework applied to Sentinel-1 C-band SAR time series data processed within Google Earth Engine. The final value for each pixel and seasonal window represents the percentage of valid Sentinel-1 acquisitions during which that pixel was classified as inundated, expressed on a scale of 0 to 100. Four seasonal compositing windows are produced per year, yielding 20 seasonal inundation layers per study area. Products are delivered at 10 m spatial resolution.",
   "extent": {
     "spatial": {
       "bbox": [[-180.0, 45.0, 180.0, 90.0]]
@@ -19,7 +19,7 @@
       "interval": [["2021-01-01T00:00:00Z", "2025-12-31T23:59:59Z"]]
     }
   },
-  "keywords": ["wetlands", "Arctic", "land cover", "wetland classification", "Northwest Territories", "Sweden", "Earth Observation", "remote sensing", "Sentinel-1", "Sentinel-2"],
+  "keywords": ["wetlands", "Arctic", "inundation", "surface water", "SAR", "Northwest Territories", "Sweden", "Earth Observation", "remote sensing", "Sentinel-1"],
   "osc:project": "eowetmet",
   "osc:region": "Northwest Territories, Canada; Northern Sweden",
   "osc:status": "completed",
@@ -30,14 +30,13 @@
     {"href": "../../projects/eowetmet/collection.json", "rel": "related", "title": "Project: EOWetMet", "type": "application/json"},
     {"href": "../../themes/land/catalog.json", "rel": "related", "title": "Theme: Land", "type": "application/json"},
     {"href": "../../eo-missions/sentinel-1/catalog.json", "rel": "related", "title": "EO Mission: Sentinel-1", "type": "application/json"},
-    {"href": "../../eo-missions/sentinel-2/catalog.json", "rel": "related", "title": "EO Mission: Sentinel-2", "type": "application/json"},
     {"href": "../../variables/methane/catalog.json", "rel": "related", "title": "Variable: Methane", "type": "application/json"},
-    {"href": "https://doi.org/10.5281/zenodo.20707376", "rel": "via", "title": "Access"}
+    {"href": "https://doi.org/10.5281/zenodo.20707622", "rel": "via", "title": "Access"}
   ],
-  "osc:missions": ["sentinel-1", "sentinel-2"],
+  "osc:missions": ["sentinel-1"],
   "osc:variables": ["methane"],
   "cf:parameter": [{"name": "methane"}],
-  "sci:doi": "10.5281/zenodo.20707376",
+  "sci:doi": "10.5281/zenodo.20707622",
   "themes": [{"concepts": [{"id": "land"}], "scheme": "https://github.com/stac-extensions/osc#theme"}],
   "license": "CC-BY-4.0"
 }

--- a/products/eowetmet-seasonal-inundation-nwt-sweden/collection.json
+++ b/products/eowetmet-seasonal-inundation-nwt-sweden/collection.json
@@ -1,0 +1,43 @@
+{
+  "type": "Collection",
+  "id": "eowetmet-annual-wetland-lake-classification-nwt-sweden",
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/osc/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/themes/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/cf/v0.2.0/schema.json"
+  ],
+  "created": "2026-06-17T00:00:00Z",
+  "updated": "2026-06-18T00:00:00Z",
+  "title": "EOWetMet: Annual Wetland and Lake Classification Dataset for NWT and Sweden (2021-2025)",
+  "description": "The EOWetMet Annual Wetland and Lake Classification Dataset (2021-2025) provides annual land cover maps distinguishing six wetland and lake ecosystem classes across two Arctic 500 km x 500 km study areas in the Northwest Territories (NWT), Canada, and northern Sweden, for the period 2021 to 2025. The dataset forms part of the EOWetMet Community Product Database and was developed to capture the spatial and temporal characterisation of wetland and lake inundation at high resolution, in support of bottom-up methane emission modelling and a broad range of Arctic science applications, including hydrological monitoring, permafrost and thermokarst change detection, and biodiversity assessment. The classification was produced using an Object-Based Image Analysis Random Forest framework implemented in Google Earth Engine, integrating 35 input features from multiple data categories, including Sentinel-1, Sentinel-2, ALOS PALSAR-2, ArcticDEM, ERA5, MERIT Hydro, and annual inundation information derived from Sentinel-1. Products are delivered at 10 m spatial resolution.",
+  "extent": {
+    "spatial": {
+      "bbox": [[-180.0, 45.0, 180.0, 90.0]]
+    },
+    "temporal": {
+      "interval": [["2021-01-01T00:00:00Z", "2025-12-31T23:59:59Z"]]
+    }
+  },
+  "keywords": ["wetlands", "Arctic", "land cover", "wetland classification", "Northwest Territories", "Sweden", "Earth Observation", "remote sensing", "Sentinel-1", "Sentinel-2"],
+  "osc:project": "eowetmet",
+  "osc:region": "Northwest Territories, Canada; Northern Sweden",
+  "osc:status": "completed",
+  "osc:type": "product",
+  "links": [
+    {"href": "../../catalog.json", "rel": "root", "title": "Open Science Catalog", "type": "application/json"},
+    {"href": "../catalog.json", "rel": "parent", "title": "Products", "type": "application/json"},
+    {"href": "../../projects/eowetmet/collection.json", "rel": "related", "title": "Project: EOWetMet", "type": "application/json"},
+    {"href": "../../themes/land/catalog.json", "rel": "related", "title": "Theme: Land", "type": "application/json"},
+    {"href": "../../eo-missions/sentinel-1/catalog.json", "rel": "related", "title": "EO Mission: Sentinel-1", "type": "application/json"},
+    {"href": "../../eo-missions/sentinel-2/catalog.json", "rel": "related", "title": "EO Mission: Sentinel-2", "type": "application/json"},
+    {"href": "../../variables/methane/catalog.json", "rel": "related", "title": "Variable: Methane", "type": "application/json"},
+    {"href": "https://doi.org/10.5281/zenodo.20707376", "rel": "via", "title": "Access"}
+  ],
+  "osc:missions": ["sentinel-1", "sentinel-2"],
+  "osc:variables": ["methane"],
+  "cf:parameter": [{"name": "methane"}],
+  "sci:doi": "10.5281/zenodo.20707376",
+  "themes": [{"concepts": [{"id": "land"}], "scheme": "https://github.com/stac-extensions/osc#theme"}],
+  "license": "CC-BY-4.0"
+}

--- a/projects/catalog.json
+++ b/projects/catalog.json
@@ -1256,6 +1256,12 @@
       "href": "./ai4ais/collection.json",
       "type": "application/json",
       "title": "ARTIFICIAL INTELLIGENCE FOR ICE SHELVES (AI4AIS)"
+    },
+    {
+      "rel": "child",
+      "href": "./eowetmet/collection.json",
+      "type": "application/json",
+      "title": "EO‐Driven Insights  for Advancing Arctic Wetland  and Lake Methane Emissions  Monitoring (EOWetMet)"
     }
   ],
   "updated": "2025-09-22T20:32:23.037110Z",

--- a/projects/catalog.json
+++ b/projects/catalog.json
@@ -1261,7 +1261,7 @@
       "rel": "child",
       "href": "./eowetmet/collection.json",
       "type": "application/json",
-      "title": "EO‐Driven Insights  for Advancing Arctic Wetland  and Lake Methane Emissions  Monitoring (EOWetMet)"
+      "title": "EOWetMet"
     }
   ],
   "updated": "2025-09-22T20:32:23.037110Z",

--- a/projects/catalog.json
+++ b/projects/catalog.json
@@ -1261,7 +1261,7 @@
       "rel": "child",
       "href": "./eowetmet/collection.json",
       "type": "application/json",
-      "title": "EOWetMet"
+      "title": "EOWetMet: EO‐Driven Insights for Advancing Arctic Wetland and Lake Methane Emissions Monitoring"
     }
   ],
   "updated": "2025-09-22T20:32:23.037110Z",

--- a/projects/eowetmet/collection.json
+++ b/projects/eowetmet/collection.json
@@ -1,32 +1,31 @@
 {
   "type": "Collection",
-  "stac_version": "1.1.0",
   "id": "eowetmet",
-  "title": "EOWetMet",
+  "stac_version": "1.0.0",
   "description": "Wetlands and lakes are the largest natural source of global methane emissions. Their magnitude remains poorly understood due to data availability, a limited understanding of environmental drivers, and accessibility, especially in the Arctic. Through collaboration with academic institutions, research organizations and government agencies, EOWetMet aims to advance and develop new methods and models to improve wetland and lake characterization and methane emission estimation to enhance the understanding of exchange processes in the Arctic.",
   "links": [
     {
-      "href": "../../catalog.json",
       "rel": "root",
-      "title": "Open Science Catalog",
-      "type": "application/json"
+      "href": "../../catalog.json",
+      "type": "application/json",
+      "title": "Open Science Catalog"
     },
     {
-      "href": "../catalog.json",
-      "rel": "parent",
-      "title": "Projects",
-      "type": "application/json"
-    },
-    {
-      "href": "https://c-core.ca/projects/eo-driven-insights-for-advancing-arctic-wetland-and-lake-methane-emissions-monitoring-eowetmet/",
       "rel": "via",
+      "href": "https://c-core.ca/projects/eo-driven-insights-for-advancing-arctic-wetland-and-lake-methane-emissions-monitoring-eowetmet/",
       "title": "Website"
     },
     {
-      "href": "../../themes/land/catalog.json",
+      "rel": "parent",
+      "href": "../catalog.json",
+      "type": "application/json",
+      "title": "Projects"
+    },
+    {
       "rel": "related",
-      "title": "Theme: Land",
-      "type": "application/json"
+      "href": "../../themes/land/catalog.json",
+      "type": "application/json",
+      "title": "Theme: Land"
     }
   ],
   "stac_extensions": [
@@ -34,69 +33,87 @@
     "https://stac-extensions.github.io/themes/v1.0.0/schema.json",
     "https://stac-extensions.github.io/contacts/v0.1.1/schema.json"
   ],
-  "osc:name": "EOWetMet: EO-Driven Insights for Advancing Arctic Wetland and Lake Methane Emissions Monitoring",
   "osc:status": "ongoing",
   "osc:type": "project",
   "themes": [
     {
+      "scheme": "https://github.com/stac-extensions/osc#theme",
       "concepts": [
         {
           "id": "land"
         }
-      ],
-      "scheme": "https://github.com/stac-extensions/osc#theme"
+      ]
     }
   ],
   "contacts": [
     {
       "name": "Stephen Plummer",
-      "roles": ["technical_officer"],
       "emails": [
         {
           "value": "stephen.plummer@esa.int"
         }
+      ],
+      "roles": [
+        "technical_officer"
       ]
     },
     {
       "name": "C-CORE (CA)",
-      "roles": ["consortium_member"]
+      "roles": [
+        "consortium_member"
+      ]
     },
     {
       "name": "Aurora Research Institute (CA)",
-      "roles": ["consortium_member"]
+      "roles": [
+        "consortium_member"
+      ]
     },
     {
       "name": "Flux Lab (CA)",
-      "roles": ["consortium_member"]
+      "roles": [
+        "consortium_member"
+      ]
     },
     {
       "name": "Government of Northwest Territories (CA)",
-      "roles": ["consortium_member"]
+      "roles": [
+        "consortium_member"
+      ]
     },
     {
       "name": "Harvard University (USA)",
-      "roles": ["consortium_member"]
+      "roles": [
+        "consortium_member"
+      ]
     },
     {
       "name": "Memorial University of Newfoundland and Labrador (CA)",
-      "roles": ["consortium_member"]
+      "roles": [
+        "consortium_member"
+      ]
     },
     {
       "name": "TerraMotion (CA)",
-      "roles": ["consortium_member"]
+      "roles": [
+        "consortium_member"
+      ]
     },
     {
       "name": "Université de Montréal (CA)",
-      "roles": ["consortium_member"]
+      "roles": [
+        "consortium_member"
+      ]
     },
     {
       "name": "Wilfrid Laurier University (CA)",
-      "roles": ["consortium_member"]
+      "roles": [
+        "consortium_member"
+      ]
     }
   ],
   "updated": "2026-06-16T00:00:00Z",
-  "start_datetime": "2024-11-19T00:00:00Z",
-  "end_datetime": "2026-10-31T23:59:59Z",
+  "title": "EOWetMet",
   "extent": {
     "spatial": {
       "bbox": [
@@ -119,4 +136,3 @@
   },
   "license": "proprietary"
 }
-

--- a/projects/eowetmet/collection.json
+++ b/projects/eowetmet/collection.json
@@ -1,7 +1,7 @@
 {
   "type": "Collection",
   "id": "eowetmet",
-  "stac_version": "1.0.0",
+  "stac_version": "1.1.0",
   "description": "Wetlands and lakes are the largest natural source of global methane emissions. Their magnitude remains poorly understood due to data availability, a limited understanding of environmental drivers, and accessibility, especially in the Arctic. Through collaboration with academic institutions, research organizations and government agencies, EOWetMet aims to advance and develop new methods and models to improve wetland and lake characterization and methane emission estimation to enhance the understanding of exchange processes in the Arctic.",
   "links": [
     {
@@ -14,6 +14,11 @@
       "rel": "via",
       "href": "https://c-core.ca/projects/eo-driven-insights-for-advancing-arctic-wetland-and-lake-methane-emissions-monitoring-eowetmet/",
       "title": "Website"
+    },
+    {
+      "rel": "via",
+      "href": "https://eo4society.esa.int/projects/eowetmet/",
+      "title": "EO4Society Link"
     },
     {
       "rel": "parent",
@@ -113,7 +118,7 @@
     }
   ],
   "updated": "2026-06-16T00:00:00Z",
-  "title": "EOWetMet",
+  "title": "EOWetMet: EO‐Driven Insights for Advancing Arctic Wetland and Lake Methane Emissions Monitoring",
   "extent": {
     "spatial": {
       "bbox": [

--- a/projects/eowetmet/collection.json
+++ b/projects/eowetmet/collection.json
@@ -1,0 +1,122 @@
+{
+  "type": "Collection",
+  "stac_version": "1.1.0",
+  "id": "eowetmet",
+  "title": "EOWetMet",
+  "description": "Wetlands and lakes are the largest natural source of global methane emissions. Their magnitude remains poorly understood due to data availability, a limited understanding of environmental drivers, and accessibility, especially in the Arctic. Through collaboration with academic institutions, research organizations and government agencies, EOWetMet aims to advance and develop new methods and models to improve wetland and lake characterization and methane emission estimation to enhance the understanding of exchange processes in the Arctic.",
+  "links": [
+    {
+      "href": "../../catalog.json",
+      "rel": "root",
+      "title": "Open Science Catalog",
+      "type": "application/json"
+    },
+    {
+      "href": "../catalog.json",
+      "rel": "parent",
+      "title": "Projects",
+      "type": "application/json"
+    },
+    {
+      "href": "https://c-core.ca/projects/eo-driven-insights-for-advancing-arctic-wetland-and-lake-methane-emissions-monitoring-eowetmet/",
+      "rel": "via",
+      "title": "Website"
+    },
+    {
+      "href": "../../themes/land/catalog.json",
+      "rel": "related",
+      "title": "Theme: Land",
+      "type": "application/json"
+    }
+  ],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/osc/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/themes/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/contacts/v0.1.1/schema.json"
+  ],
+  "osc:name": "EOWetMet: EO-Driven Insights for Advancing Arctic Wetland and Lake Methane Emissions Monitoring",
+  "osc:status": "ongoing",
+  "osc:type": "project",
+  "themes": [
+    {
+      "concepts": [
+        {
+          "id": "land"
+        }
+      ],
+      "scheme": "https://github.com/stac-extensions/osc#theme"
+    }
+  ],
+  "contacts": [
+    {
+      "name": "Stephen Plummer",
+      "roles": ["technical_officer"],
+      "emails": [
+        {
+          "value": "stephen.plummer@esa.int"
+        }
+      ]
+    },
+    {
+      "name": "C-CORE (CA)",
+      "roles": ["consortium_member"]
+    },
+    {
+      "name": "Aurora Research Institute (CA)",
+      "roles": ["consortium_member"]
+    },
+    {
+      "name": "Flux Lab (CA)",
+      "roles": ["consortium_member"]
+    },
+    {
+      "name": "Government of Northwest Territories (CA)",
+      "roles": ["consortium_member"]
+    },
+    {
+      "name": "Harvard University (USA)",
+      "roles": ["consortium_member"]
+    },
+    {
+      "name": "Memorial University of Newfoundland and Labrador (CA)",
+      "roles": ["consortium_member"]
+    },
+    {
+      "name": "TerraMotion (CA)",
+      "roles": ["consortium_member"]
+    },
+    {
+      "name": "Université de Montréal (CA)",
+      "roles": ["consortium_member"]
+    },
+    {
+      "name": "Wilfrid Laurier University (CA)",
+      "roles": ["consortium_member"]
+    }
+  ],
+  "updated": "2026-06-16T00:00:00Z",
+  "start_datetime": "2024-11-19T00:00:00Z",
+  "end_datetime": "2026-10-31T23:59:59Z",
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -180.0,
+          45.0,
+          180.0,
+          90.0
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "2024-11-19T00:00:00Z",
+          "2026-10-31T23:59:59Z"
+        ]
+      ]
+    }
+  },
+  "license": "proprietary"
+}
+


### PR DESCRIPTION
This pull request adds the EOWetMet project entry and seven associated product entries to the Open Science Catalog. EOWetMet (EO-Driven Insights for Advancing Arctic Wetland and Lake Methane Emissions Monitoring) is an ESA-funded project led by C-CORE. Products include Pan-Arctic methane flux datasets and regional wetland, inundation, and lake ice classification products for Northwest Territories, Canada, and northern Sweden.